### PR TITLE
fixed bad parental relations

### DIFF
--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -245,6 +245,7 @@ class Tributary(ComponentResource):
                     Tributary.CLEAN
                 ].bucket.bucket,
             },
+            opts=ResourceOptions(parent=self),
         )
 
         etl_lambda_function, etl_lambda_permission = (

--- a/capeinfra/objectstorage.py
+++ b/capeinfra/objectstorage.py
@@ -28,6 +28,7 @@ class VersionedBucket(ComponentResource):
             versioning_configuration=aws.s3.BucketVersioningV2VersioningConfigurationArgs(
                 status="Enabled"
             ),
+            opts=ResourceOptions(parent=self),
         )
 
         # We also need to register all the expected outputs for this component
@@ -47,5 +48,9 @@ class VersionedBucket(ComponentResource):
             The newly created bucket object.
         """
         return aws.s3.BucketObjectv2(
-            f"{self.name}-{name}", bucket=self.bucket.id, key=key, source=source
+            f"{self.name}-{name}",
+            bucket=self.bucket.id,
+            key=key,
+            source=source,
+            opts=ResourceOptions(parent=self),
         )

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -219,6 +219,7 @@ class DataCrawler(ComponentResource):
                     "GLUE_CRAWLER_NAME": self.crawler.name,
                 }
             },
+            opts=ResourceOptions(parent=self),
         )
         # Give our function permission to invoke
         # Add a bucket notification to trugger our lambda automatically
@@ -229,6 +230,7 @@ class DataCrawler(ComponentResource):
                 function=self.trigger_function.arn,
                 principal="s3.amazonaws.com",
                 source_arn=bucket.arn,
+                opts=ResourceOptions(parent=self),
             )
             aws.s3.BucketNotification(
                 f"{self.name}-bucket-notification",
@@ -239,7 +241,9 @@ class DataCrawler(ComponentResource):
                         lambda_function_arn=self.trigger_function.arn,
                     )
                 ],
-                opts=ResourceOptions(depends_on=[crawler_function_permission]),
+                opts=ResourceOptions(
+                    depends_on=[crawler_function_permission], parent=self
+                ),
             )
 
 


### PR DESCRIPTION
# TO TEST
* grab this branch
* destroy anything currently deployed to aws (you can do it without, but you'r on your own to find the correct new resource hierarchy when previewing. it may just work right)
* `pulumi preview` with this branch
* compare the hierarchy that is displayed to the previous resource hierarchy (see attachment below). note the previous one has a bunch of resources with the stack as a parent where they should belong to other resources instead)
* make sure the new hierarchy seems logically correct (the only top level children of the stack should be the meta, datalakehouse, and our custom classifier.

[pulumi-up-bad-parents.md](https://github.com/user-attachments/files/15890469/pulumi-up-bad-parents.md)
