### PR TITLE
Add descriptive tags and fix/shorten resource names

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -4,10 +4,10 @@ config:
     cape-cod:meta:
         glue:
             etl:
-                - name: gphl-cre-alert-etl
+                - name: etl-gphl-cre
                   key: glue/etl/etl_gphl_cre_alert.py
                   srcpth: ./assets/etl/etl_gphl_cre_alert.py
-                - name: tnl-alert-etl
+                - name: etl-tnl
                   key: glue/etl/etl_tnl_alert.py
                   srcpth: ./assets/etl/etl_tnl_alert.py
     cape-cod:swimlanes:

--- a/__main__.py
+++ b/__main__.py
@@ -10,13 +10,24 @@ from capeinfra.swimlanes.private import PrivateSwimlane
 # namespace things
 CAPE_STACK_NS = pulumi.get_stack()
 
+# we have very little length available for resource names (56 chars after taking
+# into account the random 7 chars added to each name to ensure uniqueness). so
+# we're going to split the stack name on `-` and only use the first char of each
+# word as the namespace. fingers crossed we don't end up with stacks that
+# resolve to the same thing...
+stack_ns = "".join([t[0] for t in CAPE_STACK_NS.split("-")])
+
 # general stack scaffolding
-cape_meta = CapeMeta(f"{CAPE_STACK_NS}-meta")
+cape_meta = CapeMeta(f"{stack_ns}-meta", desc_name=f"{CAPE_STACK_NS} Meta ")
 
 # private swimlane setup
-private_swimlane = PrivateSwimlane(f"{CAPE_STACK_NS}-privatelane")
+private_swimlane = PrivateSwimlane(
+    f"{stack_ns}-pvsl", desc_name=f"{CAPE_STACK_NS} private swimlane"
+)
 
 # here there be data
 datalake_house = DatalakeHouse(
-    f"{CAPE_STACK_NS}-datalakehouse", cape_meta.automation_assets_bucket.bucket
+    f"{stack_ns}-dlh",
+    cape_meta.automation_assets_bucket.bucket,
+    desc_name=f"{CAPE_STACK_NS} private swimlane",
 )

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -6,6 +6,8 @@ from pulumi import ComponentResource, Config, ResourceOptions
 from capeinfra.objectstorage import VersionedBucket
 from capeinfra.pipeline.data import DataCrawler, EtlJob
 
+from ..pulumi import DescribedComponentResource
+
 
 class DatalakeHouse(ComponentResource):
     """Top level object in the CAPE infrastructure for datalake storage."""
@@ -112,7 +114,7 @@ class CatalogDatabase(ComponentResource):
         )
 
 
-class Tributary(ComponentResource):
+class Tributary(DescribedComponentResource):
     """Represents a single domain in the data lake.
 
     A tributary in the CAPE datalake sense is an encapsulation of:
@@ -187,11 +189,10 @@ class Tributary(ComponentResource):
             bucket_cfg: The config dict for te bucket, as specified in the
                         pulumi stack config.
         """
-        bucket_name = (
-            bucket_cfg.get("name") or f"{self.name}-{bucket_type}-bucket"
-        )
+        bucket_name = bucket_cfg.get("name") or f"{self.name}-{bucket_type}"
         self.buckets[bucket_type] = VersionedBucket(
             bucket_name,
+            desc_name=f"{self.desc_name} {bucket_type}",
             opts=ResourceOptions(parent=self),
         )
 

--- a/capeinfra/meta/capemeta.py
+++ b/capeinfra/meta/capemeta.py
@@ -1,19 +1,21 @@
 """Contains resources used by the whole CAPE infra deployment."""
 
-from pulumi import ComponentResource, Config, FileAsset, ResourceOptions
+from pulumi import Config, FileAsset, ResourceOptions
 
 from ..objectstorage import VersionedBucket
+from ..pulumi import DescribedComponentResource
 
 
-class CapeMeta(ComponentResource):
+class CapeMeta(DescribedComponentResource):
     """Contains resources needed by all parts of the infra."""
 
-    def __init__(self, name, opts=None):
+    def __init__(self, name, **kwargs):
         # This maintains parental relationships within the pulumi stack
-        super().__init__("capeinfra:meta:capemeta:CapeMeta", name, None, opts)
-
+        super().__init__("capeinfra:meta:capemeta:CapeMeta", name, **kwargs)
         self.automation_assets_bucket = VersionedBucket(
-            f"{name}-automation-assets", opts=ResourceOptions(parent=self)
+            f"{name}-assets",
+            desc_name=f"{self.desc_name} automation assets",
+            opts=ResourceOptions(parent=self),
         )
 
         # Setup for the glue script assets

--- a/capeinfra/meta/capemeta.py
+++ b/capeinfra/meta/capemeta.py
@@ -13,7 +13,7 @@ class CapeMeta(DescribedComponentResource):
         # This maintains parental relationships within the pulumi stack
         super().__init__("capeinfra:meta:capemeta:CapeMeta", name, **kwargs)
         self.automation_assets_bucket = VersionedBucket(
-            f"{name}-assets",
+            f"{name}-assets-vbkt",
             desc_name=f"{self.desc_name} automation assets",
             opts=ResourceOptions(parent=self),
         )

--- a/capeinfra/objectstorage.py
+++ b/capeinfra/objectstorage.py
@@ -25,7 +25,7 @@ class VersionedBucket(DescribedComponentResource):
         self.bucket = aws.s3.BucketV2(
             f"{self.name}-s3",
             opts=ResourceOptions(parent=self),
-            tags={"desc-name": f"{self.desc_name} S3 Bucket"},
+            tags={"desc_name": f"{self.desc_name} S3 Bucket"},
         )
 
         self.versioning = aws.s3.BucketVersioningV2(

--- a/capeinfra/objectstorage.py
+++ b/capeinfra/objectstorage.py
@@ -4,29 +4,35 @@
 #       aws, gcp, and azure (we're only implementing aws at this time though)
 
 import pulumi_aws as aws
-from pulumi import Archive, Asset, ComponentResource, ResourceOptions
+from pulumi import Archive, Asset, ResourceOptions
+
+from .pulumi import DescribedComponentResource
 
 
-class VersionedBucket(ComponentResource):
+class VersionedBucket(DescribedComponentResource):
     """An object storage location with versioning turned on."""
 
-    def __init__(self, name, opts=None):
+    def __init__(self, name, **kwargs):
         # This maintains parental relationships within the pulumi stack
         super().__init__(
-            "capeinfra:objectstorage:S3VersionedBucket", name, None, opts
+            "capeinfra:objectstorage:S3VersionedBucket",
+            name,
+            **kwargs,
         )
 
-        self.name = f"{name}-bucket"
+        self.name = f"{name}-s3b"
 
         self.bucket = aws.s3.BucketV2(
-            f"{self.name}", opts=ResourceOptions(parent=self)
+            f"{self.name}",
+            opts=ResourceOptions(parent=self),
+            tags={"desc-name": f"{self.desc_name} S3 Bucket"},
         )
 
         self.versioning = aws.s3.BucketVersioningV2(
-            f"{name}-versioning",
+            f"{self.name}-vrsn",
             bucket=self.bucket.id,
             versioning_configuration=aws.s3.BucketVersioningV2VersioningConfigurationArgs(
-                status="Enabled"
+                status="Enabled",
             ),
             opts=ResourceOptions(parent=self),
         )

--- a/capeinfra/objectstorage.py
+++ b/capeinfra/objectstorage.py
@@ -20,10 +20,10 @@ class VersionedBucket(DescribedComponentResource):
             **kwargs,
         )
 
-        self.name = f"{name}-s3b"
+        self.name = f"{name}"
 
         self.bucket = aws.s3.BucketV2(
-            f"{self.name}",
+            f"{self.name}-s3",
             opts=ResourceOptions(parent=self),
             tags={"desc-name": f"{self.desc_name} S3 Bucket"},
         )

--- a/capeinfra/pulumi.py
+++ b/capeinfra/pulumi.py
@@ -1,0 +1,20 @@
+"""Module of subclasses of pulumi objects."""
+
+from pulumi import ComponentResource
+
+
+class DescribedComponentResource(ComponentResource):
+    """Extension of ComponentResource that takes a descriptive name."""
+
+    def __init__(self, *args, desc_name=None, **kwargs):
+        """Constructor.
+
+        Takes all the same args/kwargs as pulumi's ComponentResource in addition
+        to the ones below.
+
+        Args:
+            desc_name: A descriptive name that can be added to tags for child
+                       components because names are so restricted in length.
+        """
+        super().__init__(*args, **kwargs)
+        self.desc_name = desc_name

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -2,19 +2,21 @@
 
 from abc import abstractmethod
 
-from pulumi import ComponentResource, Config
+from pulumi import Config
+
+from .pulumi import DescribedComponentResource
 
 
-class ScopedSwimlane(ComponentResource):
+class ScopedSwimlane(DescribedComponentResource):
     """Base class for all scoped swimlanes.
 
     A scoped swimlane is the logical grouping of public, protected or private
     resources in the CAPE infra.
     """
 
-    def __init__(self, name, opts=None):
+    def __init__(self, *args, **kwargs):
         # This maintains parental relationships within the pulumi stack
-        super().__init__(self.type_name, name, None, opts=opts)
+        super().__init__(self.type_name, *args, **kwargs)
         self._cfg_dict = None
 
     @property

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -12,9 +12,9 @@ from ..swimlane import ScopedSwimlane
 class PrivateSwimlane(ScopedSwimlane):
     """Contains resources for the private swimlane of the CAPE Infra."""
 
-    def __init__(self, name, opts=None):
+    def __init__(self, name, *args, **kwargs):
         # This maintains parental relationships within the pulumi stack
-        super().__init__(name, opts)
+        super().__init__(name, *args, **kwargs)
 
         self.vpc = aws.ec2.Vpc(
             f"{name}-vpc",
@@ -26,7 +26,10 @@ class PrivateSwimlane(ScopedSwimlane):
                 enable_dns_support=True,
                 # NOTE: to set the name of a VPC resource, you have to add a
                 #       tag with the key `Name`. yay consistency :smh:
-                tags={"Name": f"{name}-vpc"},
+                tags={
+                    "Name": f"{name}-vpc",
+                    "desc_name": f"{self.desc_name} VPC",
+                },
             ),
             opts=ResourceOptions(parent=self),
         )

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -16,18 +16,22 @@ class PrivateSwimlane(ScopedSwimlane):
         # This maintains parental relationships within the pulumi stack
         super().__init__(name, *args, **kwargs)
 
+        vpc_name = f"{name}-vpc"
+
         self.vpc = aws.ec2.Vpc(
-            f"{name}-vpc",
+            vpc_name,
             args=aws.ec2.VpcArgs(
                 cidr_block=self.get_config_dict().get(
                     "cidr-block", self.default_cfg["cidr-block"]
                 ),
                 enable_dns_hostnames=True,
                 enable_dns_support=True,
-                # NOTE: to set the name of a VPC resource, you have to add a
-                #       tag with the key `Name`. yay consistency :smh:
+                # NOTE: to set the name of a VPC resource (the name that's
+                #       visible within AWS), you have to add a tag with the key
+                #       `Name`. this is the only resource encountered to date
+                #       that acts that way. yay consistency :smh:
                 tags={
-                    "Name": f"{name}-vpc",
+                    "Name": vpc_name,
                     "desc_name": f"{self.desc_name} VPC",
                 },
             ),


### PR DESCRIPTION
# TO TEST

* pull down this branch
* `pulumi preview`
  * make sure the resource names in the preview seem ok and somewhat readable
 * `pulumi up` (everything should already have been destroyed)
   * for all AWS resources (except notifications and policies/attachments which i can't find a way to look at), ensure there is a tag with a `desc_name` key and a value that is descriptive as to what the resource is. 
   * note that some of the descriptions cannot know very specific information and will end up the same as other similar descriptions (e.g. the descriptions for the HAI ETL jobs are both the same even though they are for different file types)
