### PR TITLE
feat(etl): add GPHL sequencing PDF ETL script

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -13,6 +13,9 @@ config:
                 - name: etl-fastx
                   key: glue/etl/etl_fasta_fastq.py
                   srcpth: ./assets/etl/etl_fasta_fastq.py
+                - name: etl-gphl-sequencing
+                  key: glue/etl/etl_gphl_sequencing_alert.py
+                  srcpth: ./assets/etl/etl_gphl_sequencing_alert.py
     cape-cod:swimlanes:
         private:
             # TODO: This is huge. way bigger than we need. For growth but also
@@ -50,6 +53,14 @@ config:
                                 - docx
                             pymodules:
                                 - python-docx==1.1.2
+                          - name: gphl-sequencing
+                            script: glue/etl/etl_gphl_sequencing_alert.py
+                            prefix: gphl-sequencing
+                            suffixes:
+                                - pdf
+                            pymodules:
+                                - tabula-py==2.9.3
+                                - pypdf==4.3.1
             - name: genomics
               buckets:
                   raw:

--- a/assets/README.md
+++ b/assets/README.md
@@ -19,3 +19,4 @@ need to be manually updated here.
 
 -   `etl/etl_gphl_cre_alert.py` - from [etl-gphl-cre-alert](https://github.com/cape-ph/etl-gphl-cre-alert)
 -   `etl/etl_tnl_alert.py` - from [etl-tnl-alert](https://github.com/cape-ph/etl-tnl-alert)
+-   `etl/etl_gphl_sequencing.py` - from [etl-gphl-sequencing-alert](https://github.com/cape-ph/etl-gphl-sequencing-alert)

--- a/assets/etl/etl_gphl_sequencing_alert.py
+++ b/assets/etl/etl_gphl_sequencing_alert.py
@@ -79,13 +79,13 @@ try:
     reader = PdfReader(f)
     page = reader.pages[0]
     date_reported = page.extract_text().split("\n")[3].strip()
-    datetime.strptime(date_reported,'%m/%d/%Y')
+    datetime.strptime(date_reported, "%m/%d/%Y")
 except ValueError as err:
     err_message = (
-            f"ERROR - Could not properly read sequencing report date. "
-            f"ETL will continue."
-            f"{err}"
-        )
+        f"ERROR - Could not properly read sequencing report date. "
+        f"ETL will continue."
+        f"{err}"
+    )
 
     logger.error(err_message)
 
@@ -98,10 +98,10 @@ try:
     genes = tables[1]
 except (IndexError, KeyError) as err:
     err_message = (
-            f"ERROR - Could not properly read sequencing PDF tables. "
-            f"ETL Cannot continue."
-            f"{err}"
-        )
+        f"ERROR - Could not properly read sequencing PDF tables. "
+        f"ETL Cannot continue."
+        f"{err}"
+    )
 
     logger.error(err_message)
 

--- a/assets/etl/etl_gphl_sequencing_alert.py
+++ b/assets/etl/etl_gphl_sequencing_alert.py
@@ -1,0 +1,119 @@
+"""ETL script for raw Epi/HAI sequencing alert pdf."""
+
+import io
+import sys
+
+import boto3 as boto3
+from awsglue.context import GlueContext
+from awsglue.utils import getResolvedOptions
+from pypdf import PdfReader
+from pyspark.sql import SparkSession
+from tabula.io import read_pdf
+
+# for our purposes here, the spark and glue context are only (currently) needed
+# to get the logger.
+spark_ctx = SparkSession.builder.getOrCreate()  # pyright: ignore
+glue_ctx = GlueContext(spark_ctx)
+logger = glue_ctx.get_logger()
+
+# TODO:
+#   - add error handling for the format of the document being incorrect
+#   - figure out how we want to name and namespace clean files (e.g. will we
+#     take the object key we're given, strip the extension and replace it with
+#     one for the new format, or will we do something else)
+#   - see what we can extract out of here to be useful for other ETLs. imagine
+#     we'd have a few different things that could be made into a reusable
+#     package
+
+parameters = getResolvedOptions(
+    sys.argv,
+    [
+        "RAW_BUCKET_NAME",
+        "ALERT_OBJ_KEY",
+        "CLEAN_BUCKET_NAME",
+    ],
+)
+
+raw_bucket_name = parameters["RAW_BUCKET_NAME"]
+alert_obj_key = parameters["ALERT_OBJ_KEY"]
+clean_bucket_name = parameters["CLEAN_BUCKET_NAME"]
+
+# NOTE: for now we'll take the alert object key and change out the file
+#       extension for the clean data (leaving all namespacing and such). this
+#       will probably need to change
+clean_obj_key = alert_obj_key.replace(".pdf", ".csv")
+
+# NOTE: May need some creds here
+s3_client = boto3.client("s3")
+
+# try to get the pdf object from S3 and handle any error that would keep us
+# from continuing.
+response = s3_client.get_object(Bucket=raw_bucket_name, Key=alert_obj_key)
+
+status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+
+if status != 200:
+    err = (
+        f"ERROR - Could not get object {alert_obj_key} from bucket "
+        f"{raw_bucket_name}. ETL Cannot continue."
+    )
+
+    logger.error(err)
+
+    # NOTE: need to properly handle exception stuff here, and we probably want
+    #       this going somewhere very visible (e.g. SNS topic or a perpetual log
+    #       as someone will need to be made aware)
+    raise Exception(err)
+
+logger.info(f"Obtained object {alert_obj_key} from bucket {raw_bucket_name}.")
+
+# handle the document itself...
+
+# the response should contain a StreamingBody object that needs to be converted
+# to a file like object to make the pdf libraries happy
+f = io.BytesIO(response.get("Body").read())
+
+# get the report date from the 4th line of the pdf
+reader = PdfReader(f)
+page = reader.pages[0]
+date_reported = page.extract_text().split("\n")[3]
+
+# get two tables from the pdf
+tables = read_pdf(f, multiple_tables=True, pages=2)
+assert isinstance(tables, list)
+mlst_st = tables[0]
+genes = tables[1].set_index("Unnamed: 0").T
+
+# filter the columns we need and join the tables together
+interim = mlst_st[["Accession_ID", "WGS_ID", "MLST_ST"]]
+genes_interim = genes.filter(regex="(NDM|KPC|IMP|OXA|VIM|CMY)", axis=1)
+interim = interim.join(genes_interim, on="WGS_ID")
+interim["Date Reported"] = date_reported
+
+# write out the transformed data
+with io.StringIO() as csv_buff:
+    interim.to_csv(csv_buff, index=False)
+
+    response = s3_client.put_object(
+        Bucket=clean_bucket_name, Key=clean_obj_key, Body=csv_buff.getvalue()
+    )
+
+    status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+
+    if status != 200:
+        err = (
+            f"ERROR - Could not write transformed data object {clean_obj_key} "
+            f"to bucket {clean_bucket_name}. ETL Cannot continue."
+        )
+
+        logger.error(err)
+
+        # NOTE: need to properly handle exception stuff here, and we probably
+        #       want this going somewhere very visible (e.g. SNS topic or a
+        #       perpetual log as someone will need to be made aware)
+        raise Exception(err)
+
+    logger.info(
+        f"Transformed {raw_bucket_name}/{alert_obj_key} and wrote result "
+        f"to {clean_bucket_name}/{clean_obj_key}"
+    )

--- a/assets/etl/etl_gphl_sequencing_alert.py
+++ b/assets/etl/etl_gphl_sequencing_alert.py
@@ -94,6 +94,7 @@ except ValueError as err:
 try:
     # get two tables from the pdf
     tables = read_pdf(f, multiple_tables=True, pages=2)
+    assert isinstance(tables, list)
     mlst_st = tables[0]
     genes = tables[1]
 except (IndexError, KeyError) as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ python-dateutil>=2.9.0,<3.0.0
 python-docx>=1.1.0,<2.0.0
 # fast[a|q] requirements
 pyfastx>=2.1.0,<3.0.0
+# gphl sequencing requirements
+tabula-py>=2.9.0,<3.0.0
+pypdf>=4.3.0,<5.0.0


### PR DESCRIPTION
This adds the GPHL sequencing ETL script from [cape-ph/etl-gphl-sequencing-alert](https://github.com/cape-ph/etl-gphl-sequencing-alert) into the infrastructure.

## To Test

- Grab the `240717-CPO-seq-report-MOCK.pdf` file from the test data folder on Box (under `gphl-sequencing` subfolder)
- Upload it to the HAI raw bucket with the prefix of `gphl-sequencing/`
- Check the Glue Jobs to see that it run and was successful
- Check the clean bucket to see the generated output
- Can also check the glue crawler after it's next scheduled crawl to see that it was crawled and indexed into the data catalog