### PR TITLE
Formalize our usage of the Pulumi configuration

### DIFF
--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -263,8 +263,6 @@ class Tributary(CapeComponentResource):
 
         Args:
             bucket_type: The type ('raw'/'clean') of the bucket being created.
-            bucket_cfg: The config dict for te bucket, as specified in the
-                        pulumi stack config.
         """
         bucket_config = self.config.get("buckets", bucket_type)
         bucket_name = bucket_config.get(

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -10,6 +10,7 @@ from capeinfra.iam import (
 )
 from capeinfra.objectstorage import VersionedBucket
 from capeinfra.pipeline.data import DataCrawler, EtlJob
+from capeinfra.util.config import CapeConfig
 
 from ..pulumi import DescribedComponentResource
 
@@ -31,8 +32,7 @@ class DatalakeHouse(DescribedComponentResource):
 
         self.name = f"{name}"
 
-        config = Config("cape-cod")
-        datalake_config = config.require_object("datalakehouse")
+        datalake_config = CapeConfig("datalakehouse")
 
         aws_config = Config("aws")
         self.aws_region = aws_config.require("region")

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -23,6 +23,7 @@ class DatalakeHouse(CapeComponentResource):
         name: str,
         auto_assets_bucket: aws.s3.BucketV2,
         *args,
+        config="datalakehouse",
         **kwargs,
     ):
         # This maintains parental relationships within the pulumi stack
@@ -30,7 +31,7 @@ class DatalakeHouse(CapeComponentResource):
             "capeinfra:datalake:DatalakeHouse",
             name,
             *args,
-            config="datalakehouse",
+            config=config,
             **kwargs,
         )
 
@@ -306,11 +307,9 @@ class Tributary(CapeComponentResource):
                 f"{vbname}-crwl",
                 bucket,
                 self.catalog,
-                classifiers=crawler_cfg.get("classifiers", []),
-                schedule=crawler_cfg.get("schedule"),
-                excludes=crawler_cfg.get("exclude"),
                 opts=ResourceOptions(parent=self),
                 desc_name=f"{self.desc_name} {bucket_type} data crawler",
+                config=crawler_cfg,
             )
 
     def configure_etl(
@@ -337,12 +336,6 @@ class Tributary(CapeComponentResource):
                 self.buckets[Tributary.RAW].bucket,
                 self.buckets[Tributary.CLEAN].bucket,
                 auto_assets_bucket,
-                default_args={
-                    "--additional-python-modules": ",".join(cfg["pymodules"]),
-                    "--CLEAN_BUCKET_NAME": self.buckets[
-                        Tributary.CLEAN
-                    ].bucket.bucket,
-                },
                 opts=ResourceOptions(parent=self),
                 desc_name=(f"{self.desc_name} raw to clean ETL job"),
                 config=cfg,

--- a/capeinfra/meta/capemeta.py
+++ b/capeinfra/meta/capemeta.py
@@ -2,28 +2,28 @@
 
 from pulumi import FileAsset, ResourceOptions
 
-from capeinfra.util.config import CapeConfig
-
 from ..objectstorage import VersionedBucket
-from ..pulumi import DescribedComponentResource
+from ..pulumi import CapeComponentResource
 
 
-class CapeMeta(DescribedComponentResource):
+class CapeMeta(CapeComponentResource):
     """Contains resources needed by all parts of the infra."""
 
     def __init__(self, name, **kwargs):
         # This maintains parental relationships within the pulumi stack
-        super().__init__("capeinfra:meta:capemeta:CapeMeta", name, **kwargs)
+        super().__init__(
+            "capeinfra:meta:capemeta:CapeMeta",
+            name,
+            config="meta",
+            **kwargs,
+        )
         self.automation_assets_bucket = VersionedBucket(
             f"{name}-assets-vbkt",
             desc_name=f"{self.desc_name} automation assets",
             opts=ResourceOptions(parent=self),
         )
 
-        # Setup for the glue script assets
-        meta_config = CapeConfig("meta")
-
-        for etl_def in meta_config.get("glue", "etl", default=[]):
+        for etl_def in self.config.get("glue", "etl", default=[]):
             self.automation_assets_bucket.add_object(
                 etl_def["name"],
                 key=etl_def["key"],

--- a/capeinfra/objectstorage.py
+++ b/capeinfra/objectstorage.py
@@ -3,10 +3,10 @@
 import pulumi_aws as aws
 from pulumi import Archive, Asset, ResourceOptions
 
-from .pulumi import DescribedComponentResource
+from .pulumi import CapeComponentResource
 
 
-class VersionedBucket(DescribedComponentResource):
+class VersionedBucket(CapeComponentResource):
     """An object storage location with versioning turned on."""
 
     def __init__(self, name, **kwargs):

--- a/capeinfra/pipeline/batch.py
+++ b/capeinfra/pipeline/batch.py
@@ -6,7 +6,7 @@ import pulumi_aws as aws
 from pulumi import Input, ResourceOptions
 
 from ..iam import get_inline_role, get_instance_profile
-from ..pulumi import DescribedComponentResource
+from ..pulumi import CapeComponentResource
 
 
 # NOTE: Is there a better way to define and maintain validated data structures
@@ -52,7 +52,7 @@ def new_batch_compute_resources(
     return BatchComputeResources(**params)
 
 
-class BatchCompute(DescribedComponentResource):
+class BatchCompute(CapeComponentResource):
     """A batch compute environment."""
 
     def __init__(

--- a/capeinfra/pipeline/batch.py
+++ b/capeinfra/pipeline/batch.py
@@ -14,7 +14,9 @@ class BatchCompute(CapeComponentResource):
     def default_config(self):
         return {
             "resources": {
+                # A list of AWS EC2 instance types to request
                 "instance_types": ["c4.large"],
+                # The maximum number of vCPUs in an environment
                 "max_vcpus": 16,
             }
         }

--- a/capeinfra/pipeline/batch.py
+++ b/capeinfra/pipeline/batch.py
@@ -1,7 +1,5 @@
 """Abstractions for batch pipelines."""
 
-from typing import NotRequired, Sequence, TypedDict
-
 import pulumi_aws as aws
 from pulumi import Input, ResourceOptions
 
@@ -9,58 +7,22 @@ from ..iam import get_inline_role, get_instance_profile
 from ..pulumi import CapeComponentResource
 
 
-# NOTE: Is there a better way to define and maintain validated data structures
-# in python that resolve to a dictionary and have required/optional fields?
-class BatchComputeResources(TypedDict):
-    """A class for defining resources for instances in an AWS Batch compute environment
-
-    Attributes:
-        instance_types: A list of AWS EC2 instance types to request
-        max_vcpus: The maximum number of vCPUs in an environment
-        desired_vcpus: The desired number of vCPUs in an environment (Optional)
-        min_vcpus: The minimum number of vCPUs in an environment (Optional)
-    """
-
-    instance_types: Sequence[str]
-    max_vcpus: int
-    desired_vcpus: NotRequired[int]
-    min_vcpus: NotRequired[int]
-
-
-def new_batch_compute_resources(
-    instance_types: Sequence[str] = ["c4.large"],
-    max_vcpus: int = 16,
-    desired_vcpus: int | None = None,
-    min_vcpus: int | None = None,
-):
-    """Create a new BatchComputeResources dictionary with set defaults
-
-    Args:
-        instance_types: A list of AWS EC2 instance types to request
-        max_vcpus: The maximum number of vCPUs in an environment
-        desired_vcpus: The desired number of vCPUs in an environment (Optional)
-        min_vcpus: The minimum number of vCPUs in an environment (Optional)
-
-    Returns:
-        A `BatchComputeResources` typed dictionary
-    """
-    params = {"instance_types": instance_types, "max_vcpus": max_vcpus}
-    if desired_vcpus is not None:
-        params["desired_vcpus"] = desired_vcpus
-    if min_vcpus is not None:
-        params["min_vcpus"] = min_vcpus
-    return BatchComputeResources(**params)
-
-
 class BatchCompute(CapeComponentResource):
     """A batch compute environment."""
+
+    @property
+    def default_config(self):
+        return {
+            "resources": {
+                "instance_types": ["c4.large"],
+                "max_vcpus": 16,
+            }
+        }
 
     def __init__(
         self,
         name: Input[str],
-        image_id: Input[str],
-        subnets: Sequence[Input[str]],
-        resources: BatchComputeResources,
+        subnets: dict[str, aws.ec2.Subnet],
         *args,
         **kwargs,
     ):
@@ -133,6 +95,14 @@ class BatchCompute(CapeComponentResource):
 
         # self.key_pair = aws.ec2.KeyPair(f"{self.name}-kypr")
 
+        env_subnets = []
+        for subnet_name in self.config.get("subnets"):
+            subnet = subnets.get(subnet_name)
+            assert (
+                subnet is not None
+            ), f"Unknown subnet in compute environment {name}: {subnet_name}"
+            env_subnets.append(subnet.id)
+
         self.compute_environment = aws.batch.ComputeEnvironment(
             f"{self.name}-btch",
             service_role=self.service_role.arn,
@@ -145,11 +115,11 @@ class BatchCompute(CapeComponentResource):
                 # SSHing into the machines (plus inbound requests should
                 # probably be blocked anyway)
                 # ec2_key_pair=self.key_pair.key_name,
-                image_id=image_id,
+                image_id=self.config.get("image"),
                 placement_group=self.placement_group.name,
                 security_group_ids=[self.security_group.id],
-                subnets=subnets,
-                **resources,
+                subnets=env_subnets,
+                **self.config.get("resources"),
             ),
             opts=ResourceOptions(parent=self),
         )

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -36,8 +36,17 @@ class DataCrawler(CapeComponentResource):
     @property
     def default_config(self):
         return {
-            "schedule": "0 * * * ? *",  # NECKBEARD SPEAK FOR EVERY HOUR
+            # a cron formatted schedule string for the crawler's periodicity.
+            # NOTE: this cannot be faster than every 5
+            # minutes. see here for more:
+            # https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html
+            "schedule": "0 * * * ? *",
+            # A list of custom classifiers for the crawler, if any.
             "classifiers": [],
+            # a list of exclude paths for the crawler. see here for more:
+            # https://docs.aws.amazon.com/glue/latest/dg/define-crawler.html#define-crawler-choose-data-sources
+            # NOTE: at this time, all given exclusions apply to all buckets the
+            # crawler is set up for.
             "excludes": [],
         }
 

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -194,6 +194,12 @@ class DataCrawler(CapeComponentResource):
 class EtlJob(CapeComponentResource):
     """An extract/transform/load job."""
 
+    @property
+    def default_config(self):
+        return {
+            "max_concurrent_runs": 5,
+        }
+
     def __init__(
         self,
         name: str,
@@ -273,12 +279,6 @@ class EtlJob(CapeComponentResource):
             tags={"desc_name": self.desc_name or "AWS Glue ETL Job"},
         )
         self.register_outputs({"job_name": self.job.name})
-
-    @property
-    def default_config(self):
-        return {
-            "max_concurrent_runs": 5,
-        }
 
     def add_trigger_function(self):
         """Adds a trigger function to kick off this job.

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -10,7 +10,7 @@ from ..iam import (
     get_start_crawler_policy,
     get_start_etl_job_policy,
 )
-from ..pulumi import DescribedComponentResource
+from ..pulumi import CapeComponentResource
 
 CAPE_CSV_STANDARD_CLASSIFIER = "cape-csv-standard-classifier"
 
@@ -28,7 +28,7 @@ CUSTOM_CLASSIFIERS = {
 }
 
 
-class DataCrawler(DescribedComponentResource):
+class DataCrawler(CapeComponentResource):
     """A crawler for object storage."""
 
     # default schedule for our crawlers will be every hour
@@ -204,7 +204,7 @@ class DataCrawler(DescribedComponentResource):
             )
 
 
-class EtlJob(DescribedComponentResource):
+class EtlJob(CapeComponentResource):
     """An extract/transform/load job."""
 
     def __init__(

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -1,5 +1,7 @@
 """Abstractions for data pipelines."""
 
+from copy import deepcopy
+
 import pulumi_aws as aws
 from pulumi import AssetArchive, FileAsset, Output, ResourceOptions
 
@@ -31,8 +33,13 @@ CUSTOM_CLASSIFIERS = {
 class DataCrawler(CapeComponentResource):
     """A crawler for object storage."""
 
-    # default schedule for our crawlers will be every hour
-    DEFAULT_SCHEDULE = "0 * * * ? *"
+    @property
+    def default_config(self):
+        return {
+            "schedule": "0 * * * ? *",  # NECKBEARD SPEAK FOR EVERY HOUR
+            "classifiers": [],
+            "excludes": [],
+        }
 
     def __init__(
         self,
@@ -40,9 +47,6 @@ class DataCrawler(CapeComponentResource):
         buckets: aws.s3.BucketV2 | list[aws.s3.BucketV2],
         db: aws.glue.CatalogDatabase,
         *args,
-        classifiers=None,
-        schedule: str | None = None,
-        excludes: list | None = None,
         prefix: str | None = None,
         **kwargs,
     ):
@@ -55,16 +59,6 @@ class DataCrawler(CapeComponentResource):
             prefix: A prefix string within a bucket to crawl which limits the
                     content that will be indexed by the crawler.
             db: The catalog database where the crawler will write metadata.
-            classifiers: A list of custom classifiers for the crawler, if any.
-            schedule: a cron formatted schedule string for the crawler's
-                      periodicity. NOTE: this cannot be faster than every 5
-                      minutes. see here for more:
-                      https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html
-            excludes: a list of exclude paths for the crawler. see here for
-                      more:
-                      https://docs.aws.amazon.com/glue/latest/dg/define-crawler.html#define-crawler-choose-data-sources
-                      NOTE: at this time, all given exclusions apply to all
-                      buckets the crawler is set up for.
             opts: The ResourceOptions to apply to the crawler resource.
         Returns:
         """
@@ -75,9 +69,6 @@ class DataCrawler(CapeComponentResource):
         self.buckets = buckets = (
             buckets if isinstance(buckets, list) else [buckets]
         )
-
-        self.schedule = schedule or self.DEFAULT_SCHEDULE
-        self.excludes = excludes or []
 
         # get a role for the crawler
         self.crawler_role = get_inline_role(
@@ -95,15 +86,11 @@ class DataCrawler(CapeComponentResource):
 
         # if we have specified custom classifiers in the config, get the actual
         # names for them from our mapping.
-        custom_classifiers = (
-            [
-                CUSTOM_CLASSIFIERS[c].name
-                for c in classifiers
-                if CUSTOM_CLASSIFIERS.get(c)
-            ]
-            if classifiers
-            else []
-        )
+        custom_classifiers = [
+            CUSTOM_CLASSIFIERS[c].name
+            for c in self.config.get("classifiers", default=[])
+            if CUSTOM_CLASSIFIERS.get(c)
+        ]
 
         self.crawler = aws.glue.Crawler(
             f"{self.name}-gcrwl",
@@ -114,12 +101,12 @@ class DataCrawler(CapeComponentResource):
                     path=bucket.bucket.apply(
                         lambda b: f"s3://{b}/{prefix+'/' if prefix else ''}"
                     ),
-                    exclusions=self.excludes,
+                    exclusions=self.config["excludes"],
                 )
                 for bucket in buckets
             ],
             classifiers=custom_classifiers,
-            schedule=f"cron({self.schedule})",
+            schedule=f"cron({self.config['schedule']})",
             opts=ResourceOptions(parent=self),
             tags={"desc_name": self.desc_name or "AWS Glue Data Crawler"},
         )
@@ -214,7 +201,7 @@ class EtlJob(CapeComponentResource):
         clean_bucket: aws.s3.BucketV2,
         script_bucket: aws.s3.BucketV2,
         *args,
-        default_args: dict | None = None,
+        default_args: dict = {},
         **kwargs,
     ):
         """Constructor.
@@ -258,6 +245,16 @@ class EtlJob(CapeComponentResource):
             srvc_policy_attach=None,
             opts=ResourceOptions(parent=self),
         )
+
+        default_args = deepcopy(default_args)
+        if (
+            "pymodules" in self.config
+            and "--additional-python-modules" not in default_args
+        ):
+            default_args["--additional-python-modules"] = ",".join(
+                self.config["pymodules"]
+            )
+        default_args["--CLEAN_BUCKET_NAME"] = self.clean_bucket.bucket
 
         self.job = aws.glue.Job(
             self.name,

--- a/capeinfra/pulumi.py
+++ b/capeinfra/pulumi.py
@@ -16,7 +16,7 @@ class CapeComponentResource(ComponentResource):
         *args,
         desc_name=None,
         config: dict | str = {},
-        config_name: str | None = "cape-cod",
+        config_name: str | None = None,
         **kwargs,
     ):
         """Constructor.

--- a/capeinfra/pulumi.py
+++ b/capeinfra/pulumi.py
@@ -1,20 +1,50 @@
 """Module of subclasses of pulumi objects."""
 
+from abc import abstractmethod
+
 from pulumi import ComponentResource
 
+from capeinfra.util.config import CapeConfig
 
-class DescribedComponentResource(ComponentResource):
-    """Extension of ComponentResource that takes a descriptive name."""
 
-    def __init__(self, *args, desc_name=None, **kwargs):
+class CapeComponentResource(ComponentResource):
+    """Extension of ComponentResource that takes a descriptive name and sets up
+    configuration."""
+
+    def __init__(
+        self,
+        *args,
+        desc_name=None,
+        config: dict | str = {},
+        config_name: str | None = "cape-cod",
+        **kwargs,
+    ):
         """Constructor.
 
         Takes all the same args/kwargs as pulumi's ComponentResource in addition
         to the ones below.
 
         Args:
+            config: A configuration dictionary or a string to pull an object
+                    from the Pulumi config
+            config_name: the name of the section in the pulumi config (Optional,
+                         only used if config is a string)
             desc_name: A descriptive name that can be added to tags for child
                        components because names are so restricted in length.
         """
         super().__init__(*args, **kwargs)
+        self._config = CapeConfig(
+            config, config_name=config_name, default=self.default_config
+        )
         self.desc_name = desc_name
+
+    @property
+    @abstractmethod
+    def default_config(self) -> dict:
+        """Abstract property to get the default configuration of the component."""
+        pass
+
+    @property
+    def config(self):
+        """Return the config object for the component."""
+        return self._config

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -3,9 +3,10 @@
 from abc import abstractmethod
 
 import pulumi_aws as aws
-from pulumi import Config, ResourceOptions
+from pulumi import ResourceOptions
 
 from capeinfra.pipeline.batch import BatchCompute, new_batch_compute_resources
+from capeinfra.util.config import CapeConfig
 from capeinfra.util.naming import disemvowel
 
 from .pulumi import DescribedComponentResource
@@ -21,7 +22,7 @@ class ScopedSwimlane(DescribedComponentResource):
     def __init__(self, basename, *args, **kwargs):
         # This maintains parental relationships within the pulumi stack
         super().__init__(self.type_name, basename, *args, **kwargs)
-        self._cfg_dict = None
+        self._config = CapeConfig("swimlanes", default=self.default_cfg)
         self._inet_gw = None
         self.basename = basename
         self.private_subnets = dict[str, aws.ec2.Subnet]()
@@ -82,18 +83,10 @@ class ScopedSwimlane(DescribedComponentResource):
 
         return self._inet_gw
 
-    def get_config_dict(self):
-        """Gets the config dict for the swimlane based on its setup.
-
-        Returns:
-            The configuration dict for the swimlane. This comes from the pulumi
-            config under the key `cape-cod:swimlanes`
-        """
-        if self._cfg_dict is None:
-            config = Config("cape-cod")
-            all_sl_config = config.require_object("swimlanes")
-            self._cfg_dict = all_sl_config.get(self.scope, self.default_cfg)
-        return self._cfg_dict
+    @property
+    def config(self):
+        """Return the config object for the swimlane."""
+        return self._config
 
     def create_vpc(self):
         """Create the VPC for the swimlane."""
@@ -102,9 +95,7 @@ class ScopedSwimlane(DescribedComponentResource):
         self.vpc = aws.ec2.Vpc(
             self.vpc_name,
             args=aws.ec2.VpcArgs(
-                cidr_block=self.get_config_dict().get(
-                    "cidr-block", self.default_cfg["cidr-block"]
-                ),
+                cidr_block=self.config.get("cidr-block"),
                 enable_dns_hostnames=True,
                 enable_dns_support=True,
                 # NOTE: to set the name of a VPC resource (the name that's
@@ -131,9 +122,7 @@ class ScopedSwimlane(DescribedComponentResource):
         self.public_subnet = aws.ec2.Subnet(
             pubsn_name,
             vpc_id=self.vpc.id,
-            cidr_block=self.get_config_dict()
-            .get("public-subnet", self.default_cfg["public-subnet"])
-            .get("cidr-block", None),
+            cidr_block=self.config.get("public-subnet", "cidr-block"),
             map_public_ip_on_launch=True,
             tags={
                 "Name": pubsn_name,
@@ -175,11 +164,8 @@ class ScopedSwimlane(DescribedComponentResource):
         all outgoing traffic to the NAT gateway in the public subnet if
         configured.
         """
-        # private_sn_configs = self.get_config_dict().get("private-subnets", self.default_cfg["private-subnets"])
 
-        for psnc in self.get_config_dict().get(
-            "private-subnets", self.default_cfg["private-subnets"]
-        ):
+        for psnc in self.config.get("private-subnets", default=[]):
             config_sn_name = psnc.get("name")
             # devowel the configured name to try to save some characters in max
             # string lengths for identifiers when constructing the subnet name
@@ -223,11 +209,7 @@ class ScopedSwimlane(DescribedComponentResource):
         all outgoing traffic to the NAT gateway in the public subnet if
         configured.
         """
-        for env in (
-            self.get_config_dict()
-            .get("compute", self.default_cfg["compute"])
-            .get("environments", [])
-        ):
+        for env in self.config.get("compute", "environments", default=[]):
             name = env.get("name")
             subnets = []
             for subnet_name in env.get("subnets"):

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 import pulumi_aws as aws
 from pulumi import ResourceOptions
 
-from capeinfra.pipeline.batch import BatchCompute, new_batch_compute_resources
+from capeinfra.pipeline.batch import BatchCompute
 from capeinfra.util.config import CapeConfig
 from capeinfra.util.naming import disemvowel
 
@@ -205,18 +205,8 @@ class ScopedSwimlane(CapeComponentResource):
         """
         for env in self.config.get("compute", "environments", default=[]):
             name = env.get("name")
-            subnets = []
-            for subnet_name in env.get("subnets"):
-                subnet = self.private_subnets.get(subnet_name)
-                assert (
-                    subnet is not None
-                ), f"Unknown subnet in compute environment {name}: {subnet_name}"
-                subnets.append(subnet.id)
             self.compute_environments[name] = BatchCompute(
                 name,
-                image_id=env.get("image"),
-                subnets=subnets,
-                resources=new_batch_compute_resources(
-                    **env.get("resources", {})
-                ),
+                subnets=self.private_subnets,
+                config=env,
             )

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -48,8 +48,8 @@ class PrivateSwimlane(ScopedSwimlane):
         return "private"
 
     @property
-    def default_cfg(self) -> dict:
-        """Implementation of abstract property `default_cfg`.
+    def default_config(self) -> dict:
+        """Implementation of abstract property `default_config`.
 
         The default config has one public subnet only in the 10.0.0.0-255
         address space. There are no private subnets.

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -18,6 +18,27 @@ from ..util.naming import disemvowel
 class PrivateSwimlane(ScopedSwimlane):
     """Contains resources for the private swimlane of the CAPE Infra."""
 
+    @property
+    def default_config(self) -> dict:
+        """Implementation of abstract property `default_config`.
+
+        The default config has one public subnet only in the 10.0.0.0-255
+        address space. There are no private subnets.
+
+        Returns:
+            The default config dict for this swimlane.
+        """
+        return {
+            # by default (if not overridden in config) this will get ip space
+            # 10.0.0.0-255
+            "cidr-block": "10.0.0.0/24",
+            "public-subnet": {
+                "cidr-block": "10.0.0.0/24",
+            },
+            "private-subnets": [],
+            "compute": {},
+        }
+
     def __init__(self, name, *args, **kwargs):
         # This maintains parental relationships within the pulumi stack
         super().__init__(name, *args, **kwargs)
@@ -46,27 +67,6 @@ class PrivateSwimlane(ScopedSwimlane):
             The scope (public, protected, private) of the swimlane.
         """
         return "private"
-
-    @property
-    def default_config(self) -> dict:
-        """Implementation of abstract property `default_config`.
-
-        The default config has one public subnet only in the 10.0.0.0-255
-        address space. There are no private subnets.
-
-        Returns:
-            The default config dict for this swimlane.
-        """
-        return {
-            # by default (if not overridden in config) this will get ip space
-            # 10.0.0.0-255
-            "cidr-block": "10.0.0.0/24",
-            "public-subnet": {
-                "cidr-block": "10.0.0.0/24",
-            },
-            "private-subnets": [],
-            "compute": {},
-        }
 
     def create_dap_api(self):
         """Create the data analysis pipeline API for the private swimlane."""

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -29,7 +29,7 @@ class CapeConfig(dict):
     def __init__(
         self,
         config: dict | str,
-        config_name: str | None = None,
+        config_name: str = "cape-cod",
         default: dict | None = None,
     ):
         """Constructor.

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -47,7 +47,7 @@ class CapeConfig(dict):
                        is not returned.
         """
         if isinstance(config, str):
-            config = Config(config_name or "cape-cod").require_object(config)
+            config = Config(config_name).require_object(config)
             if not isinstance(config, Mapping):
                 raise TypeError(
                     f"Pulumi config value for {config_name}:{config} is not an object"

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -94,3 +94,4 @@ class CapeConfig(dict):
                    have been changed.
         """
         update_dict(self, delta)
+        return self

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -30,7 +30,7 @@ class CapeConfig(dict):
 
     def __init__(
         self,
-        config: Mapping | str,
+        config: Mapping | str = {},
         config_name: str | None = DEFAULT_CONFIG_NAME,
         default: Mapping | None = None,
     ):

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -18,6 +18,9 @@ def update_dict(base, delta: dict):
     return base
 
 
+DEFAULT_CONFIG_NAME = "cape-cod"
+
+
 class CapeConfig(dict):
     """Class for CAPE configuration objects
 
@@ -28,7 +31,7 @@ class CapeConfig(dict):
     def __init__(
         self,
         config: dict | str,
-        config_name: str | None = "cape-cod",
+        config_name: str | None = DEFAULT_CONFIG_NAME,
         default: dict | None = None,
     ):
         """Constructor.
@@ -47,7 +50,9 @@ class CapeConfig(dict):
                        is not returned.
         """
         if isinstance(config, str):
-            config = Config(config_name).require_object(config)
+            config = Config(config_name or DEFAULT_CONFIG_NAME).require_object(
+                config
+            )
             if not isinstance(config, Mapping):
                 raise TypeError(
                     f"Pulumi config value for {config_name}:{config} is not an object"

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -1,7 +1,6 @@
 """Module of configuration related utilities."""
 
 from collections.abc import Mapping
-from copy import deepcopy
 from typing import Any
 
 from pulumi import Config
@@ -29,7 +28,7 @@ class CapeConfig(dict):
     def __init__(
         self,
         config: dict | str,
-        config_name: str = "cape-cod",
+        config_name: str | None = "cape-cod",
         default: dict | None = None,
     ):
         """Constructor.
@@ -48,7 +47,7 @@ class CapeConfig(dict):
                        is not returned.
         """
         if isinstance(config, str):
-            config = Config(config_name).require_object(config)
+            config = Config(config_name or "cape-cod").require_object(config)
             if not isinstance(config, Mapping):
                 raise TypeError(
                     f"Pulumi config value for {config_name}:{config} is not an object"
@@ -77,6 +76,8 @@ class CapeConfig(dict):
                 curr = default
                 break
             curr = curr[key]
+        if curr is None:
+            curr = default
         return CapeConfig(curr) if isinstance(curr, Mapping) else curr
 
     def update(self, delta: dict):

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -1,0 +1,89 @@
+"""Module of configuration related utilities."""
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from pulumi import Config
+
+
+def update_dict(base, delta: dict):
+    if not isinstance(base, dict):
+        return delta
+    common_keys = set(base).intersection(delta)
+    new_keys = set(delta).difference(common_keys)
+    for key in common_keys:
+        base[key] = update_dict(base[key], delta[key])
+    for key in new_keys:
+        base[key] = delta[key]
+    return base
+
+
+class CapeConfig(dict):
+    """Class for CAPE configuration objects
+
+    Attributes:
+        config: The configuration object
+    """
+
+    def __init__(
+        self,
+        config: dict | str,
+        config_name: str | None = None,
+        default: dict | None = None,
+    ):
+        """Constructor.
+
+        Args:
+            config: The configuration object to instantiate from. If a string is
+                    provided it will be retrieved from Pulumi
+            config_name: The Pulumi configuration name, if none is provided then
+                         the project name is used. (Only applicable when config
+                         is a string)
+            default: The default configuration object, if any to merge the
+                     provided configuration into.
+
+        Raises:
+            TypeError: If retrieving the configuration from Pulumi and an object
+                       is not returned.
+        """
+        if isinstance(config, str):
+            config = Config(config_name).require_object(config)
+            if not isinstance(config, Mapping):
+                raise TypeError(
+                    f"Pulumi config value for {config_name}:{config} is not an object"
+                )
+        if default:
+            super().__init__(default)
+            self.update(config)
+        else:
+            super().__init__(config)
+
+    def get(self, *keys, default=None) -> Any:
+        """Retrieve an arbitrarily nested value from the configuration object,
+           fallback to a default if value is not found while traversing.
+
+        Args:
+            *keys: The list keys to search down into the configuration object
+            default: The default value to return when element not found,
+                     Default: None
+
+        Returns:
+            The retrieved value or the default if no value found
+        """
+        curr = self
+        for key in keys:
+            if not isinstance(curr, Mapping) or key not in curr:
+                return default
+            curr = dict(curr).get(key)
+        return CapeConfig(curr) if isinstance(curr, Mapping) else curr
+
+    def update(self, delta: dict):
+        """Update the configuration with values from a new table.
+
+        Args:
+            delta: An object to merge into the configuration object. Maintains
+                   original structure adding new keys and overwriting keys that
+                   have been changed.
+        """
+        update_dict(self, delta)

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -74,8 +74,9 @@ class CapeConfig(dict):
         curr = self
         for key in keys:
             if not isinstance(curr, Mapping) or key not in curr:
-                return default
-            curr = dict(curr).get(key)
+                curr = default
+                break
+            curr = curr[key]
         return CapeConfig(curr) if isinstance(curr, Mapping) else curr
 
     def update(self, delta: dict):

--- a/capeinfra/util/config.py
+++ b/capeinfra/util/config.py
@@ -6,7 +6,7 @@ from typing import Any
 from pulumi import Config
 
 
-def update_dict(base, delta: dict):
+def update_dict(base: Any, delta: Mapping):
     if not isinstance(base, dict):
         return delta
     common_keys = set(base).intersection(delta)
@@ -30,9 +30,9 @@ class CapeConfig(dict):
 
     def __init__(
         self,
-        config: dict | str,
+        config: Mapping | str,
         config_name: str | None = DEFAULT_CONFIG_NAME,
-        default: dict | None = None,
+        default: Mapping | None = None,
     ):
         """Constructor.
 
@@ -85,7 +85,7 @@ class CapeConfig(dict):
             curr = default
         return CapeConfig(curr) if isinstance(curr, Mapping) else curr
 
-    def update(self, delta: dict):
+    def update(self, delta: Mapping):
         """Update the configuration with values from a new table.
 
         Args:


### PR DESCRIPTION
Currently we have many different methods/models of interacting with the Pulumi configuration and it is fragmented and hard to recover at a given point what is really going on in any arbitrary place in the configuration. This PR is an investigation into formalizing, centralizing, and improving how we handle configuration through the infrastructure.

### Plan

This is the _current_ plan that is up to changing at any moment through development and discussion, will be kept up to date.

- [x] Manage all interaction of the Pulumi configuration with a `util.config` library
- [x] Centralize the idea of the "configuration" rather than placing that information arbitrarily
  - Keep in mind that we want to maintain the ease of adding/removing pieces in the configuration
- [x] Make it so the configuration is interlaced with the defaults and "fully resolved" as step 1 in the infrastructure to make sure it gets the understanding of configuration finalized before the infrastructure starts
  - This is happening at the component level and each component is in charge of the configuration for themselves. If components want to access each others configurations, they should do so by accessing the `.config` variable from a component that is _created_ and _initialized_

## TO TEST

Run `pulumi preview` on `main` and this branch and see that there are no differences
 
Closes #69