### PR TITLE
added a config value for type of deployment

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1,5 +1,12 @@
 encryptionsalt: v1:PZ8pzBjNSVk=:v1:SGEZ1sCsg7aCAu5i:Ntz5ud8IjMsY1H5RLI/n6zmuuIK9sQ==
 config:
+    # This block is for meta about the deployment itself that may be reused in
+    # later config settings.
+    deployment:meta: &depmet
+        # stage-name is used anywhere we need the deployment stage name and
+        # should be values like "dev", "prod", etc. There is exact no exact
+        # enumeration of values yet.
+        stage-name: "dev"
     aws:region: us-east-2
     cape-cod:meta:
         glue:
@@ -34,6 +41,13 @@ config:
                   # if True, the private subnet's outgoing traffic will be
                   # routed to the NAT gateway for egress to the internet
                   egress-to-nat: True
+            # NOTE: the apis section here will likely need to be re-worked as we
+            #       move the api to a real host name, add certs, and all the
+            #       things. for now just trying to get the stage name
+            #       configurable from the root deployment:meta section
+            api:
+                dap:
+                    meta: *depmet
             compute:
                 environments:
                     - name: analysis

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -36,6 +36,13 @@ class PrivateSwimlane(ScopedSwimlane):
                 "cidr-block": "10.0.0.0/24",
             },
             "private-subnets": [],
+            "api": {
+                "dap": {
+                    "meta": {
+                        "stage-name": "dev",
+                    },
+                },
+            },
             "compute": {},
         }
 
@@ -172,11 +179,16 @@ class PrivateSwimlane(ScopedSwimlane):
             # TODO: ISSUE #65
             opts=ResourceOptions(
                 parent=self,
-                # NOTE: not specying these led to the deployment being
+                # NOTE: not specifying these led to the deployment being
                 #       constructed before things it depends on
                 depends_on=[post_new_dap_method, post_new_dap_integration],
             ),
         )
+
+        # NOTE: our stage name is in the config file, and if it is not defined
+        #       we rally want the deployment to fail. so we'll let the KeyError
+        #       happen and not try to do anything about it
+        stage_name = self.config.get("api", "dap", "meta", "stage-name")
 
         # make a stage for the deployment manually.
         # NOTE: we could make this implicitly by just setting stage_name on the
@@ -184,8 +196,6 @@ class PrivateSwimlane(ScopedSwimlane):
         #       about weedy things that lead to deletion and addition of stages
         #       on redeployments if done this way, which ultimately leads to a
         #       service interruption.
-        # TODO: ISSUE #66
-        stage_name = "dev"
         self.dap_api_deployment_stage = aws.apigateway.Stage(
             f"{self.basename}-dapapi-dplymntstg",
             stage_name=stage_name,


### PR DESCRIPTION
**NOTE:** This all assumes that
- the current state of the deployed system has a DAP API and that it is in a "dev" stage (which it most likely is set up as).
- you are logged into the aws account already

# TO TEST
- check out this branch
- attempt a `pulumi preview` with everything as-is. you should see no changes in the DAP API stage resources
- modify the dev config file to change the `stage-name` in `deployment:meta` to some other value (e.g. `devdev`)
- again try pulumi preview. you should now see that it wants to replace the existing stage with a new one.
- revert all changes in the local repo. you are done.