### PR TITLE
107 separate tracked and non tracked assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.py[cod]
 venv/
 .DS_Store
-# TODO: ISSUE #107
-assets/tls
+assets-untracked/

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -64,7 +64,7 @@ config:
                 # default to "udp"
                 transport-proto: "udp"
                 tls:
-                    dir: ./assets/tls/vpn
+                    dir: ./assets-untracked/tls/vpn
                     ca-cert: ca.crt
                     server-key: server.key
                     server-cert: server.crt

--- a/extra-doc/README.vpn.md
+++ b/extra-doc/README.vpn.md
@@ -101,9 +101,10 @@ VPN will not continue.
 **_Because the keys should be protected, it is very important that the
 directories set up and referenced in the configuration not end up in the
 repository._** The repository is currently setup to ignore files in
-`assets/tls`. We recommend using subdirectories here to manage tls assets being
-deployed so they do not end up in the repo accidentally. If you use other
-directories, be careful.
+`assets-untracked`. We recommend using subdirectories here to manage tls assets
+(and other secrects that should not end up in the repo) being deployed so they
+do not end up in the repo accidentally. If you use other directories, **_BE
+CAREFUL_**.
 
 The following configuration block is supported for VPN (within the `private`
 block in the `cape-cod:swimlanes` block):
@@ -120,7 +121,7 @@ vpn:
     # default to "udp"
     transport-proto: "udp"
     tls:
-        dir: ./assets/tls/vpn
+        dir: ./assets-untracked/tls/vpn
         # all files must exist in the above `dir`
         ca-cert: ca.crt
         server-key: server.key


### PR DESCRIPTION
# TO TEST

* review should suffice
* (bonus points) additional test is to `pulumi preview` with the vpn TLS files being moved into new `assets-untracked` directory at root of repo (with same hierarchy as they were in before). there should be no changes