### PR TITLE
Get AWS Batch working

### DIFF
--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -93,6 +93,58 @@ def get_start_crawler_policy(crawler: str) -> str:
     )
 
 
+def get_nextflow_executor_policy() -> str:
+    """Get a role policy statement for an EC2 instance of Nextflow.
+
+    Returns:
+        The policy statement as a json encoded string.
+    """
+
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "batch:CancelJob",
+                        "batch:DescribeComputeEnvironments",
+                        "batch:DescribeJobDefinitions",
+                        "batch:DescribeJobQueues",
+                        "batch:DescribeJobs",
+                        "batch:ListJobs",
+                        "batch:RegisterJobDefinition",
+                        "batch:SubmitJob",
+                        "batch:TagResource",
+                        "batch:TerminateJob",
+                        "ec2:DescribeInstanceAttribute",
+                        "ec2:DescribeInstanceStatus",
+                        "ec2:DescribeInstanceTypes",
+                        "ec2:DescribeInstances",
+                        "ecr:BatchCheckLayerAvailability",
+                        "ecr:BatchGetImage",
+                        "ecr:DescribeImageScanFindings",
+                        "ecr:DescribeImages",
+                        "ecr:DescribeRepositories",
+                        "ecr:GetAuthorizationToken",
+                        "ecr:GetDownloadUrlForLayer",
+                        "ecr:GetLifecyclePolicy",
+                        "ecr:GetLifecyclePolicyPreview",
+                        "ecr:GetRepositoryPolicy",
+                        "ecr:ListImages",
+                        "ecr:ListTagsForResource",
+                        "ecs:DescribeContainerInstances",
+                        "ecs:DescribeTasks",
+                        "logs:GetLogEvents",
+                        "s3:*",
+                    ],
+                    "Resource": ["*"],
+                },
+            ],
+        },
+    )
+
+
 def get_start_etl_job_policy(job: str) -> str:
     """Get a role policy statement for starting an ETL job.
 

--- a/capeinfra/pipeline/batch.py
+++ b/capeinfra/pipeline/batch.py
@@ -55,7 +55,7 @@ class BatchCompute(CapeComponentResource):
             f"{self.name}-instnc",
             f"{self.desc_name} AWS batch instance role",
             "",
-            "batch.amazonaws.com",
+            "ec2.amazonaws.com",
             # TODO: add policy (ISSUE #73)
             srvc_policy_attach="arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
             opts=ResourceOptions(parent=self),

--- a/capeinfra/pipeline/batch.py
+++ b/capeinfra/pipeline/batch.py
@@ -24,6 +24,7 @@ class BatchCompute(CapeComponentResource):
     def __init__(
         self,
         name: Input[str],
+        vpc: aws.ec2.Vpc,
         subnets: dict[str, aws.ec2.Subnet],
         *args,
         **kwargs,
@@ -86,6 +87,7 @@ class BatchCompute(CapeComponentResource):
                     "cidr_blocks": ["0.0.0.0/0"],
                 }
             ],
+            vpc_id=vpc.id,
             opts=ResourceOptions(parent=self),
         )
 

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -232,6 +232,7 @@ class ScopedSwimlane(CapeComponentResource):
             name = env.get("name")
             self.compute_environments[name] = BatchCompute(
                 name,
+                vpc=self.vpc,
                 subnets=self.private_subnets,
                 config=env,
             )


### PR DESCRIPTION
This fixes some issues that arose when testing out AWS Batch job submissions with the job queue and the related resources. This fixes those issues as well as creates a role which can be attached to an EC2 instance to be able to submit jobs to AWS Batch without the need for managing Access Keys.