### PR TITLE
ci: add pre-commit configuration for safer development

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.6.0
+      hooks:
+          - id: trailing-whitespace
+          - id: mixed-line-ending
+          - id: check-yaml
+          - id: check-toml
+          - id: check-merge-conflict
+    - repo: https://github.com/psf/black
+      rev: 24.8.0
+      hooks:
+          - id: black
+    - repo: https://github.com/pycqa/isort
+      rev: 5.13.2
+      hooks:
+          - id: isort
+    - repo: https://github.com/crate-ci/typos
+      rev: v1.24.6
+      hooks:
+          - id: typos

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 python 3.11
 pulumi 3
+pre-commit 3


### PR DESCRIPTION
This adds configuration for `pre-commit` if someone uses it