### PR TITLE
temporary handling of output s3 buckets for data analysis pipeline output

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -23,7 +23,7 @@ config:
                 - name: etl-gphl-sequencing
                   key: glue/etl/etl_gphl_sequencing_alert.py
                   srcpth: ./assets/etl/etl_gphl_sequencing_alert.py
-                # TODO: ISSUE #144 this is for the inital bactopia results
+                # TODO: ISSUE #144 this is for the initial bactopia results
                 #       handling. it may not be best to have here long term, and
                 #       we don't know yet how were managing these things. so for
                 #       now it's here (we also need to think about how we handle

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -23,6 +23,15 @@ config:
                 - name: etl-gphl-sequencing
                   key: glue/etl/etl_gphl_sequencing_alert.py
                   srcpth: ./assets/etl/etl_gphl_sequencing_alert.py
+                # TODO: ISSUE #144 this is for the inital bactopia results
+                #       handling. it may not be best to have here long term, and
+                #       we don't know yet how were managing these things. so for
+                #       now it's here (we also need to think about how we handle
+                #       pipelines that may have different etl needs for
+                #       different versions)
+                - name: etl-bactopia-results
+                  key: glue/etl/etl_bactopia_results.py
+                  srcpth: ./assets/etl/etl_bactopia_results.py
     cape-cod:swimlanes:
         private:
             # This is the private domain that will setup in the cloud provider

--- a/__main__.py
+++ b/__main__.py
@@ -20,15 +20,17 @@ stack_ns = "".join([t[0] for t in CAPE_STACK_NS.split("-")])
 # general stack scaffolding
 cape_meta = CapeMeta(f"{stack_ns}-meta", desc_name=f"{CAPE_STACK_NS} Meta ")
 
-# private swimlane setup
-private_swimlane = PrivateSwimlane(
-    f"{stack_ns}-pvsl",
-    desc_name=f"{CAPE_STACK_NS} private swimlane",
-)
-
 # here there be data
 datalake_house = DatalakeHouse(
     f"{stack_ns}-dlh",
     cape_meta.automation_assets_bucket.bucket,
     desc_name=f"{CAPE_STACK_NS} private swimlane",
+)
+
+# private swimlane setup
+private_swimlane = PrivateSwimlane(
+    f"{stack_ns}-pvsl",
+    cape_meta.automation_assets_bucket.bucket,
+    desc_name=f"{CAPE_STACK_NS} private swimlane",
+    data_catalog=datalake_house.catalog,
 )

--- a/assets/etl/etl_bactopia_results.py
+++ b/assets/etl/etl_bactopia_results.py
@@ -1,0 +1,100 @@
+"""ETL script for the initial subset of bactopia results we'll handle."""
+
+import io
+import os.path
+import sys
+
+import boto3 as boto3
+import pandas as pd
+from awsglue.context import GlueContext
+from awsglue.utils import getResolvedOptions
+from pyspark.sql import SparkSession
+
+# for our purposes here, the spark and glue context are only (currently) needed
+# to get the logger.
+spark_ctx = SparkSession.builder.getOrCreate()  # pyright: ignore
+glue_ctx = GlueContext(spark_ctx)
+logger = glue_ctx.get_logger()
+
+parameters = getResolvedOptions(
+    sys.argv,
+    [
+        "RAW_BUCKET_NAME",
+        "ALERT_OBJ_KEY",
+        "CLEAN_BUCKET_NAME",
+    ],
+)
+
+# TODO: we should change our generic etl concept to not use the words "raw" or
+#       "alert". probably not even "clean". Then we can get to a place where we
+#       can reuse things outside the raw/clean alert etl paradigm.
+
+raw_bucket_name = parameters["RAW_BUCKET_NAME"]
+alert_obj_key = parameters["ALERT_OBJ_KEY"]
+clean_bucket_name = parameters["CLEAN_BUCKET_NAME"]
+
+# NOTE: May need some creds here
+s3_client = boto3.client("s3")
+
+# TODO: the `transformed-results` here is for the initial bactopia data handling
+#       only and is by no means something that must be carried forward, but for
+#       now we are writing the trasformed data to the same bucket as the
+#       pre-transform data (in a different prefix) so we want a way to carry
+#       around the prefix to write to (which we don't have currently)
+clean_obj_key = os.path.join("transformed-results", alert_obj_key)
+
+# try to get the object from S3 and handle any error that would keep us
+# from continuing.
+response = s3_client.get_object(Bucket=raw_bucket_name, Key=alert_obj_key)
+
+status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+
+if status != 200:
+    err = (
+        f"ERROR - Could not get object {alert_obj_key} from bucket "
+        f"{raw_bucket_name}. ETL Cannot continue."
+    )
+
+    logger.error(err)
+
+    # NOTE: need to properly handle exception stuff here, and we probably want
+    #       this going somewhere very visible (e.g. SNS topic or a perpetual log
+    #       as someone will need to be made aware)
+    raise Exception(err)
+
+logger.info(f"Obtained object {alert_obj_key} from bucket {raw_bucket_name}.")
+
+# handle the document itself...
+
+# TODO: we don't know what we're doing with these results yet, so for now we'll
+#       just write the input file to the output location
+
+# write out the transformed data
+with io.StringIO() as sio_buff:
+
+    # TODO: write the body of the input file to `Body`
+    response = s3_client.put_object(
+        Bucket=clean_bucket_name,
+        Key=clean_obj_key,
+        Body=response.get("Body").read(),
+    )
+
+    status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+
+    if status != 200:
+        err = (
+            f"ERROR - Could not write transformed data object {clean_obj_key} "
+            f"to bucket {clean_bucket_name}. ETL Cannot continue."
+        )
+
+        logger.error(err)
+
+        # NOTE: need to properly handle exception stuff here, and we probably
+        #       want this going somewhere very visible (e.g. SNS topic or a
+        #       perpetual log as someone will need to be made aware)
+        raise Exception(err)
+
+    logger.info(
+        f"Transformed {raw_bucket_name}/{alert_obj_key} and wrote result "
+        f"to {clean_bucket_name}/{clean_obj_key}"
+    )

--- a/assets/etl/etl_bactopia_results.py
+++ b/assets/etl/etl_bactopia_results.py
@@ -25,9 +25,10 @@ parameters = getResolvedOptions(
     ],
 )
 
-# TODO: we should change our generic etl concept to not use the words "raw" or
-#       "alert". probably not even "clean". Then we can get to a place where we
-#       can reuse things outside the raw/clean alert etl paradigm.
+# TODO: ISSUE #150 we should change our generic etl concept to not use the
+#       words "raw" or "alert". probably not even "clean". Then we can get
+#       to a place where we can reuse things outside the raw/clean alert
+#       etl paradigm.
 
 raw_bucket_name = parameters["RAW_BUCKET_NAME"]
 alert_obj_key = parameters["ALERT_OBJ_KEY"]
@@ -36,11 +37,12 @@ clean_bucket_name = parameters["CLEAN_BUCKET_NAME"]
 # NOTE: May need some creds here
 s3_client = boto3.client("s3")
 
-# TODO: the `transformed-results` here is for the initial bactopia data handling
-#       only and is by no means something that must be carried forward, but for
-#       now we are writing the trasformed data to the same bucket as the
-#       pre-transform data (in a different prefix) so we want a way to carry
-#       around the prefix to write to (which we don't have currently)
+# TODO: ISSUE #144 the `transformed-results` here is for the initial bactopia
+#       data handling only and is by no means something that must be carried
+#       forward, but for now we are writing the trasformed data to the same
+#       bucket as the pre-transform data (in a different prefix) so we want a
+#       way to carry around the prefix to write to (which we don't have
+#       currently)
 clean_obj_key = os.path.join("transformed-results", alert_obj_key)
 
 # try to get the object from S3 and handle any error that would keep us
@@ -66,13 +68,12 @@ logger.info(f"Obtained object {alert_obj_key} from bucket {raw_bucket_name}.")
 
 # handle the document itself...
 
-# TODO: we don't know what we're doing with these results yet, so for now we'll
-#       just write the input file to the output location
+# TODO: ISSUE #151 we don't know what we're doing with these results yet, so
+#       for now we'll just write the input file to the output location
 
 # write out the transformed data
 with io.StringIO() as sio_buff:
 
-    # TODO: write the body of the input file to `Body`
     response = s3_client.put_object(
         Bucket=clean_bucket_name,
         Key=clean_obj_key,

--- a/assets/etl/etl_bactopia_results.py
+++ b/assets/etl/etl_bactopia_results.py
@@ -39,7 +39,7 @@ s3_client = boto3.client("s3")
 
 # TODO: ISSUE #144 the `transformed-results` here is for the initial bactopia
 #       data handling only and is by no means something that must be carried
-#       forward, but for now we are writing the trasformed data to the same
+#       forward, but for now we are writing the transformed data to the same
 #       bucket as the pre-transform data (in a different prefix) so we want a
 #       way to carry around the prefix to write to (which we don't have
 #       currently)

--- a/assets/lambda/new_dap_results_queue_notifier_lambda.py
+++ b/assets/lambda/new_dap_results_queue_notifier_lambda.py
@@ -1,0 +1,172 @@
+"""Lambda function for sending an SQS message about new DAP results in s3."""
+
+# TODO: We should look at how to minimize DRY between this and the
+#       `new_s3obj_queue_notifier.py` lambda.
+#       This is very similar to the lambda used for doing this same kind of
+#       thing on new raw data in HAI/EPI. A big difference is that there is
+#       a DynamoDB table used in the raw data case that maps a lot of the s3
+#       object data to a specific ETL function. In this case, we don't have that
+#       (yet at least) and any implementation like that would need to wait until
+#       we really know how we're going to handle pipeline data.
+
+import json
+import logging
+import os
+import urllib.parse
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+sqs_client = boto3.client("sqs")
+
+
+# TODO: ISSUE #86
+def decode_error(err: ClientError):
+    code, message = "Unknown", "Unknown"
+    if "Error" in err.response:
+        error = err.response["Error"]
+        if "Code" in error:
+            code = error["Code"]
+        if "Message" in error:
+            message = error["Message"]
+    return code, message
+
+
+# TODO: ISSUE #86
+def send_etl_message(queue_name: str, queue_url: str, qmsg: dict):
+    """Send the object info as a json message to the specified queue.
+
+    Args:
+        queue_name: The name of the queue to send the message to. This is needed
+                    to make a message group id for the fifo queue.
+        queue_url: The URL of the queue to send the message to.
+        qmsg: A dict containing info about the new S3 object and ETL job that
+              needs to be processed by ETL.
+
+    Raises:
+        ClientError: On any error in sending the message.
+    """
+    body = json.dumps(qmsg)
+    try:
+        sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody=body,
+            MessageGroupId=f"{queue_name}-raw-data-msg",
+        )
+    except ClientError as err:
+        code, message = decode_error(err)
+
+        logger.exception(
+            f"Could not place message with body ({body}) on queue at URL "
+            f"({queue_url}). {code} "
+            f"{message}"
+        )
+        raise err
+
+    logger.info(
+        f"Message ({body}) SUCCESSFULLY placed on queue at url ({queue_url})"
+    )
+
+
+def index_handler(event, context):
+    """Handler for inserting notification events into a specified queue.
+
+    Args:
+        event: The event notification object.
+        context: Context object.
+    """
+
+    queue_name = os.getenv("QUEUE_NAME")
+    etl_job_id = os.getenv("ETL_JOB_ID")
+
+    # obligatory data validation
+    if queue_name is None:
+        msg = "No queue name provided. Cannot insert notification message."
+        logger.error(msg)
+        return {"statusCode": 500, "body": msg}
+
+    # grab all the info we care about for the new s3 object from the event
+    # object.
+    # NOTE: the event structure for notifications can contain many records.
+    #       grabbing them all to handle potential of multiple uploads in a
+    #       batch. a new message will be inserted for each record
+    object_info = [
+        {
+            "bucket": rec["s3"]["bucket"]["name"],
+            "key": urllib.parse.unquote_plus(
+                rec["s3"]["object"]["key"], encoding="utf-8"
+            ),
+        }
+        for rec in event["Records"]
+    ]
+
+    try:
+        # we'll bucket the incoming object infos and use them to send our
+        # response if nothing fails miserably
+        ignored_oi = []
+        processed_oi = []
+
+        # TODO: any other error checking here? we should get an exception if
+        #       the response isn't valid...
+        response = sqs_client.get_queue_url(QueueName=queue_name)
+        queue_url = response["QueueUrl"]
+
+        for oi in object_info:
+            # deconstruct the key (s3 name, prefix, suffix)
+            prefix, _, objname = oi["key"].rpartition("/")
+            if not objname:
+                # if we didn't get an objname, the separator "/" was not found,
+                # meaning there is no prefix. so do some rearranging of
+                # variables
+                objname = prefix
+                prefix = ""
+
+            # NOTE: if the object deosn't have a file extension, suffix will end
+            #       up an empty string here. that's ok if the ETL is configured
+            #       to work for items with no extension
+            _, _, suffix = objname.rpartition(".")
+
+            # NOTE: first cut DAP results processing, we'll assume all files
+            #       coming in will be ETL'd
+            qmsg = {}
+            qmsg.update(oi)
+            qmsg.setdefault("etl_job", etl_job_id)
+
+            send_etl_message(queue_name, queue_url, qmsg)
+            processed_oi.append(oi)
+
+        # Make our return message containing info about the processed and
+        # ignored objects
+        body = ""
+
+        if processed_oi:
+            body = (
+                "The following objects passed filter criteria and were added to "
+                "the ETL queue: ["
+            )
+
+            for poi in processed_oi:
+                body = f"{body}({poi['bucket']}, {poi['key']}), "
+
+            body = f"{body}]. "
+
+        return {
+            "statusCode": 200,
+            "body": body,
+        }
+    except ClientError as err:
+        code, message = decode_error(err)
+
+        msg = (
+            f"Error during processing of new object notification for queuing. "
+            f"{code} "
+            f"{message}"
+        )
+        logger.exception(msg)
+
+        return {
+            "statusCode": 500,
+            "body": msg,
+        }

--- a/assets/lambda/new_dap_results_queue_notifier_lambda.py
+++ b/assets/lambda/new_dap_results_queue_notifier_lambda.py
@@ -1,6 +1,6 @@
 """Lambda function for sending an SQS message about new DAP results in s3."""
 
-# TODO: We should look at how to minimize DRY between this and the
+# TODO: ISSUE #150 We should look at how to minimize DRY between this and the
 #       `new_s3obj_queue_notifier.py` lambda.
 #       This is very similar to the lambda used for doing this same kind of
 #       thing on new raw data in HAI/EPI. A big difference is that there is

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -6,7 +6,7 @@ from pulumi import AssetArchive, Config, FileAsset, Output, ResourceOptions
 from capeinfra.iam import (
     get_inline_role,
     get_sqs_lambda_glue_trigger_policy,
-    get_sqs_raw_notifier_policy,
+    get_sqs_notifier_policy,
 )
 from capeinfra.objectstorage import VersionedBucket
 from capeinfra.pipeline.data import DataCrawler, EtlJob
@@ -427,7 +427,7 @@ class Tributary(CapeComponentResource):
                 qname=self.raw_data_queue.name,
                 etl_attr_ddb_table_name=etl_attrs_ddb_table.name,
             ).apply(
-                lambda args: get_sqs_raw_notifier_policy(
+                lambda args: get_sqs_notifier_policy(
                     args["qname"], args["etl_attr_ddb_table_name"]
                 )
             ),

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -289,10 +289,10 @@ def get_etl_job_s3_policy(
     )
 
 
-# TODO: this is now used for a couple of different notifiers, with and without
-#       attributes tables. the param names are a little specific to one use case
-#       only and there is a world in which we need to add other statements
-#       optionally (other than for an dynamodb table). refactor?
+# TODO: ISSUE #152 this is now used for a couple of different notifiers, with
+#       and without attributes tables. the param names are a little specific to
+#       one use case only and there is a world in which we need to add other
+#       statements optionally (other than for an dynamodb table). refactor?
 def get_sqs_notifier_policy(
     queue_name: str, etl_attr_ddb_table_name: str | None = None
 ) -> str:

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -289,61 +289,67 @@ def get_etl_job_s3_policy(
     )
 
 
-def get_sqs_raw_notifier_policy(
-    queue_name: str, etl_attr_ddb_table_name: str
+# TODO: this is now used for a couple of different notifiers, with and without
+#       attributes tables. the param names are a little specific to one use case
+#       only and there is a world in which we need to add other statements
+#       optionally (other than for an dynamodb table). refactor?
+def get_sqs_notifier_policy(
+    queue_name: str, etl_attr_ddb_table_name: str | None = None
 ) -> str:
     """Get a role policy statement for reading dynamodb and writing sqs.
 
-    This policy allows for actions on an sqs queue, a dynamodb table and
-    logging necessary for raw data handlers to place metadata about a new S3
-    object into a specific SQS queue and to read some of the metadata from a
-    dynamodb table.
+    This policy allows for actions on an sqs queue, (optionally) a dynamodb
+    table and logging necessary for raw data handlers to place metadata about
+    a new S3 object into a specific SQS queue (and to read some of the metadata
+    from a dynamodb table if configured).
 
     Args:
         queue_name: the name of the queue to grant access to.
-        etl_attr_ddb_table_name: The name of the DynamoDB table storing the ETL
-                                 attributes.
+        etl_attr_ddb_table_name: The optional name of the DynamoDB table
+                                 storing the ETL attributes.
 
     Returns:
         The policy statement as a dictionary json encoded string.
     """
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "logs:PutLogEvents",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                ],
+                "Resource": "arn:aws:logs:*:*:*",
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "sqs:GetQueueUrl",
+                    "sqs:SendMessage",
+                ],
+                "Resource": [
+                    f"arn:aws:sqs:*:*:{queue_name}",
+                ],
+            },
+        ],
+    }
 
-    return json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "logs:PutLogEvents",
-                        "logs:CreateLogGroup",
-                        "logs:CreateLogStream",
-                    ],
-                    "Resource": "arn:aws:logs:*:*:*",
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "sqs:GetQueueUrl",
-                        "sqs:SendMessage",
-                    ],
-                    "Resource": [
-                        f"arn:aws:sqs:*:*:{queue_name}",
-                    ],
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "dynamodb:DescribeTable",
-                        "dynamodb:GetItem",
-                    ],
-                    "Resource": [
-                        f"arn:aws:dynamodb:*:*:table/{etl_attr_ddb_table_name}",
-                    ],
-                },
-            ],
-        },
-    )
+    if etl_attr_ddb_table_name:
+        policy["Statement"].append(
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "dynamodb:DescribeTable",
+                    "dynamodb:GetItem",
+                ],
+                "Resource": [
+                    f"arn:aws:dynamodb:*:*:table/{etl_attr_ddb_table_name}",
+                ],
+            }
+        )
+    return json.dumps(policy)
 
 
 # TODO: may or may not be able to get a single policy for a whole api

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -5,6 +5,9 @@ from abc import abstractmethod
 import pulumi_aws as aws
 from pulumi import ResourceOptions
 
+# TODO: ISSUE #145 this import is only needed for the temporary DAP S3 handling.
+#       it should not be here after 145.
+from capeinfra.datalake.datalake import CatalogDatabase
 from capeinfra.pipeline.batch import BatchCompute
 from capeinfra.util.config import CapeConfig
 from capeinfra.util.naming import disemvowel
@@ -19,7 +22,13 @@ class ScopedSwimlane(CapeComponentResource):
     resources in the CAPE infra.
     """
 
-    def __init__(self, basename, *args, **kwargs):
+    def __init__(
+        self,
+        basename,
+        *args,
+        data_catalog: CatalogDatabase | None = None,
+        **kwargs,
+    ):
         # This maintains parental relationships within the pulumi stack
         super().__init__(
             self.type_name,
@@ -32,6 +41,12 @@ class ScopedSwimlane(CapeComponentResource):
         self.basename = basename
         self.private_subnets = dict[str, aws.ec2.Subnet]()
         self.compute_environments = dict[str, BatchCompute]()
+
+        # TODO: ISSUE #145 this member is only needed for the temporary DAP S3
+        #       handling. it should not be here after 145. if it needs to, we
+        #       should probably rethink how we expose the catalog to
+        #       non-datalake clients
+        self.data_catalog = data_catalog
         self.create_vpc()
         self.create_public_subnet()
         self.create_private_subnets()

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -17,6 +17,10 @@ from pulumi import (
     warn,
 )
 
+# TODO: ISSUE #145 This import is to support the temporary dap results s3
+#       handling.
+from capeinfra.pipeline.data import DataCrawler, EtlJob
+
 from ..iam import (
     get_bucket_reader_policy,
     get_bucket_web_host_policy,
@@ -25,6 +29,8 @@ from ..iam import (
     get_instance_profile,
     get_nextflow_executor_policy,
     get_sqs_lambda_dap_submit_policy,
+    get_sqs_lambda_glue_trigger_policy,
+    get_sqs_notifier_policy,
 )
 from ..objectstorage import VersionedBucket
 from ..swimlane import ScopedSwimlane
@@ -69,9 +75,15 @@ class PrivateSwimlane(ScopedSwimlane):
             },
         }
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(
+        self, name, auto_assets_bucket: aws.s3.BucketV2, *args, **kwargs
+    ):
+
         # This maintains parental relationships within the pulumi stack
         super().__init__(name, *args, **kwargs)
+        # TODO: is there a better way to expose the auto assets bucket since
+        #       we're now passing it to every client that needs a lambda script?
+        self.auto_assets_bucket = auto_assets_bucket
 
         aws_config = Config("aws")
         self.aws_region = aws_config.require("region")
@@ -82,6 +94,7 @@ class PrivateSwimlane(ScopedSwimlane):
         self.create_static_web_resources()
         self.create_vpn()
         self.prepare_nextflow_executor()
+        self.create_dap_results_s3()
 
     @property
     def type_name(self) -> str:
@@ -1037,3 +1050,216 @@ class PrivateSwimlane(ScopedSwimlane):
                     )
                 ),
             )
+
+    # TODO: ISSUE #144
+    def create_dap_results_s3(self):
+        """"""
+
+        # NOTE: not adding any of this to the config till we know how we want to
+        #       handle results/output s3 longer term in ISSUE #145
+        short_name = disemvowel("dapresults")
+        bucket_name = f"{self.basename}-{short_name}-vbkt"
+        crawler_cfg = {
+            "exclude": "",
+            "classifiers": [],
+        }
+        etl_cfg = {
+            "name": "dap_results",
+            # TODO: we need the handler lambda. it should be very much like the
+            #       ones for raw data (and it must support the raw bucket and
+            #       obj key like the others do).
+            "script": "glue/etl/etl_bactopia_results.py",
+            "prefix": "dap_results",
+            "suffixes": [],
+            "pymodules": [],
+        }
+
+        self.dap_results_bucket = VersionedBucket(
+            bucket_name,
+            desc_name=f"{self.desc_name} Temporary DAP Results Output Bucket",
+            opts=ResourceOptions(parent=self),
+        )
+
+        # NOTE: for this temporary bucket, we'll have a data crawler setup on
+        #       the `transformed-results` prefix. When we do our simple ETL for
+        #       this bucket, it'll need to write the results of ETL there
+        if self.data_catalog is not None:
+            DataCrawler(
+                f"{bucket_name}-crwl",
+                self.dap_results_bucket.bucket,
+                self.data_catalog.catalog_database,
+                opts=ResourceOptions(parent=self),
+                desc_name=f"{self.desc_name} Temprary DAP Results data crawler",
+                # NOTE: this is just made up for this temporary bucket
+                prefix="transformed-results",
+                config=crawler_cfg,
+            )
+
+        # this queue is where all notifications of new objects added to the
+        # temprary DAP results bucket will go
+        self.dap_results_data_queue = aws.sqs.Queue(
+            # TODO: ISSUE #68
+            f"{self.basename}-daprsltsq",
+            name=f"{self.basename}-daprsltsq.fifo",
+            content_based_deduplication=True,
+            fifo_queue=True,
+            tags={
+                "desc_name": (
+                    f"{self.desc_name} Temporary DAP results data "
+                    "notification queue"
+                )
+            },
+        )
+
+        # setup ETL job for the DAP results
+        # NOTE: depending how we implement results handling, we may need to add
+        #       a dynamo abstraction like we have for raw data ETLs. If we have
+        #       a single ETL per pipeline and we tie the results s3 buckets to
+        #       pipelines, we probably wouldn't need that.
+        dap_results_etl_job = EtlJob(
+            f"{self.basename}-ETL-{short_name}",
+            self.dap_results_bucket.bucket,
+            # TODO: this output path needs a special prefix. consider adding
+            #       this as an optional thing in the ETL config (if not
+            #       specified default to the prefix given)?
+            self.dap_results_bucket.bucket,
+            self.auto_assets_bucket,
+            opts=ResourceOptions(parent=self),
+            desc_name=(f"{self.desc_name} DAP results ETL job"),
+            config=etl_cfg,
+        )
+
+        # Lambda SQS Target setup
+        self.sqs_dap_results_trigger_role = get_inline_role(
+            f"{self.basename}-{short_name}-sqstrgrole",
+            f"{self.desc_name} Temporary DAP results data SQS trigger role",
+            "lmbd",
+            "lambda.amazonaws.com",
+            Output.all(
+                qname=self.dap_results_data_queue.name,
+                job_names=[dap_results_etl_job.job],
+            ).apply(
+                lambda args: get_sqs_lambda_glue_trigger_policy(
+                    args["qname"], args["job_names"]
+                )
+            ),
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+            opts=ResourceOptions(parent=self),
+        )
+
+        # Create our Lambda function that triggers the given glue job
+        self.dap_results_qmsg_handler = aws.lambda_.Function(
+            f"{self.basename}-{short_name}-sqslmbdtrgfnct",
+            role=self.sqs_dap_results_trigger_role.arn,
+            code=AssetArchive(
+                {
+                    # TODO: this script is usable as is for any glue job sqs
+                    #       handler, with the caveat that the glue job has to
+                    #       support a RAW_BUCKET_NAME and ALERT_OBJ_KEY env
+                    #       var (and the same sqs message format). it might be
+                    #       worth changing the job spec to take a
+                    #       `SRC_BUCKET_NAME` instead of `RAW` since not all
+                    #       sources will be really raw data.
+                    "index.py": FileAsset(
+                        "./assets/lambda/sqs_etl_job_trigger_lambda.py"
+                    )
+                }
+            ),
+            runtime="python3.11",
+            # in this case, the zip file for the lambda deployment is
+            # being created by this code. and the zip file will be
+            # called index. so the handler must be start with `index`
+            # and the actual function in the script must be named
+            # the same as the value here
+            handler="index.index_handler",
+            environment={
+                "variables": {
+                    "QUEUE_NAME": self.dap_results_data_queue.name,
+                    "ETL_JOB_ID": dap_results_etl_job.name,
+                }
+            },
+            opts=ResourceOptions(parent=self),
+            tags={
+                "desc_name": (
+                    f"{self.desc_name} Temporary DAP results sqs message "
+                    "lambda trigger function"
+                )
+            },
+        )
+
+        aws.lambda_.EventSourceMapping(
+            f"{self.basename}-{short_name}-sqslmbdatrgr",
+            event_source_arn=self.dap_results_data_queue.arn,
+            function_name=self.dap_results_qmsg_handler.arn,
+            function_response_types=["ReportBatchItemFailures"],
+        )
+
+        # Bucket notification setup
+        # get a role for the raw bucket trigger
+        self.dap_results_bucket_trigger_role = get_inline_role(
+            f"{self.basename}-{short_name}-s3trgrole",
+            f"{self.desc_name} Temporary DAP Results data S3 bucket trigger role",
+            "lmbd",
+            "lambda.amazonaws.com",
+            Output.all(
+                qname=self.dap_results_data_queue.name,
+            ).apply(lambda args: get_sqs_notifier_policy(args["qname"])),
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+            opts=ResourceOptions(parent=self),
+        )
+
+        # Create our Lambda function that triggers the given glue job
+        new_object_handler = aws.lambda_.Function(
+            f"{self.basename}-{short_name}-lmbdtrgfnct",
+            role=self.dap_results_bucket_trigger_role.arn,
+            code=AssetArchive(
+                {
+                    "index.py": FileAsset(
+                        "./assets/lambda/new_dap_results_queue_notifier_lambda.py"
+                    )
+                }
+            ),
+            runtime="python3.11",
+            # in this case, the zip file for the lambda deployment is
+            # being created by this code. and the zip file will be
+            # called index. so the handler must be start with `index`
+            # and the actual function in the script must be named
+            # the same as the value here
+            handler="index.index_handler",
+            environment={
+                "variables": {
+                    "QUEUE_NAME": self.dap_results_data_queue.name,
+                }
+            },
+            opts=ResourceOptions(parent=self),
+            tags={
+                "desc_name": (
+                    f"{self.desc_name} Temporary DAP Results data lambda "
+                    "trigger function"
+                )
+            },
+        )
+
+        # Give our function permission to invoke
+        new_obj_handler_permission = aws.lambda_.Permission(
+            f"{self.basename}-{short_name}S3-allow-lmbd",
+            action="lambda:InvokeFunction",
+            function=new_object_handler.arn,
+            principal="s3.amazonaws.com",
+            source_arn=self.dap_results_bucket.bucket.arn,
+            opts=ResourceOptions(parent=self),
+        )
+
+        aws.s3.BucketNotification(
+            f"{self.basename}-{short_name}-s3ntfn",
+            bucket=self.dap_results_bucket.bucket.id,
+            lambda_functions=[
+                aws.s3.BucketNotificationLambdaFunctionArgs(
+                    events=["s3:ObjectCreated:*"],
+                    lambda_function_arn=new_object_handler.arn,
+                )
+            ],
+            opts=ResourceOptions(
+                depends_on=[new_obj_handler_permission], parent=self
+            ),
+        )

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -81,7 +81,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         # This maintains parental relationships within the pulumi stack
         super().__init__(name, *args, **kwargs)
-        # TODO: ISSUE #153 is there a better way to expose the auto assets 
+        # TODO: ISSUE #153 is there a better way to expose the auto assets
         #       bucket since we're now passing it to every client that needs a
         #       lambda script? Same for data catalog (which is passed to the
         #       swimlane base class)
@@ -1190,10 +1190,10 @@ class PrivateSwimlane(ScopedSwimlane):
         """Create an S3 bucket for the data analysis pipeline results.
 
         This method also creates and ETL and crawler for the bucket.
-        
+
         NOTE: This is a temporary implementation. We do not intend for this to
               remain in this format as it's very copy/paste from the tributary
-              setup. 
+              setup.
         """
 
         # NOTE: not adding any of this to the config till we know how we want to
@@ -1291,8 +1291,8 @@ class PrivateSwimlane(ScopedSwimlane):
             code=AssetArchive(
                 {
                     # TODO: ISSUE #150 this script is usable as is for any glue
-                    #       job sqs handler, with the caveat that the glue job 
-                    #       has to support a RAW_BUCKET_NAME and ALERT_OBJ_KEY 
+                    #       job sqs handler, with the caveat that the glue job
+                    #       has to support a RAW_BUCKET_NAME and ALERT_OBJ_KEY
                     #       env var (and the same sqs message format). it might
                     #       be worth changing the job spec to take a
                     #       `SRC_BUCKET_NAME` instead of `RAW` since not all
@@ -1399,7 +1399,6 @@ class PrivateSwimlane(ScopedSwimlane):
                     #       all pipelines should write output to sub-prefixes
                     #       under `pipeline-output/`
                     filter_prefix="pipeline-output/",
-
                 )
             ],
             opts=ResourceOptions(

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -1228,8 +1228,8 @@ class PrivateSwimlane(ScopedSwimlane):
                 self.data_catalog.catalog_database,
                 opts=ResourceOptions(parent=self),
                 desc_name=(
-                    f"{self.desc_name} Temporary DAP Results data crawler",
-                )
+                    f"{self.desc_name} Temporary DAP Results data crawler"
+                ),
                 # NOTE: this is just made up for this temporary bucket
                 prefix="transformed-results",
                 config=crawler_cfg,


### PR DESCRIPTION
# TO TEST
This is already deployed. 

* If you upload a file in `s3://ccd-pvsl-dprslts-vbkt-s3-3141f09/pipeline-output` (any prefix under here) it should show up in `s3://ccd-pvsl-dprslts-vbkt-s3-3141f09/transformed-data/pipeline-output` (the ETL just puts the input somewhere as output right now.
* If files are uploaded to other locations in the bucket, it will not be ETL'ed