### PR TITLE
get nextflow head node running commands from lambda

### DIFF
--- a/assets/lambda/sqs_dap_submit_lambda.py
+++ b/assets/lambda/sqs_dap_submit_lambda.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import time
 
 import boto3
 from botocore.exceptions import ClientError

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -594,6 +594,33 @@ def get_sqs_lambda_dap_submit_policy(queue_name: str, table_name: str) -> str:
                         f"arn:aws:dynamodb:*:*:table/{table_name}",
                     ],
                 },
+                {
+                    "Sid": "AllowSSMExecution",
+                    "Effect": "Allow",
+                    "Action": ["ssm:SendCommand", "ssm:GetCommandInvocation"],
+                    # TODO: get this specified via parameter
+                    "Resource": [
+                        # TODO: ISSUE #158 this should be changed to have
+                        #       tag-based pairing down
+                        "arn:aws:ec2:us-east-2:767397883306:instance/*",
+                        # TODO: this isn't tied to our account
+                        "arn:aws:ssm:us-east-2::document/AWS-RunShellScript",
+                        # TODO: how do we lock this down better? this is needed
+                        #       for GetCommandInvocation and came from an error
+                        #       message, but i'm not entirely certain what exact
+                        #       resource it's not allow to access
+                        "arn:aws:ssm:us-east-2:767397883306:*",
+                    ],
+                },
+                {
+                    "Sid": "AllowEC2DescribeInstances",
+                    "Effect": "Allow",
+                    "Action": "ec2:DescribeInstances",
+                    # TODO: ISSUE #158
+                    "Resource": [
+                        "arn:aws:ec2:us-east-2:767397883306:instance/*",
+                    ],
+                },
             ],
         },
     )

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -1158,6 +1158,12 @@ class PrivateSwimlane(ScopedSwimlane):
             "ec2.amazonaws.com",
             role_policy=get_nextflow_executor_policy(),
         )
+        aws.iam.RolePolicyAttachment(
+            f"{self.basename}-instnc-ssmvcroleatch",
+            role=self.nextflow_role.name,
+            policy_arn="arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+            opts=ResourceOptions(parent=self),
+        )
         self.nextflow_role_profile = get_instance_profile(
             f"{self.basename}-nxtflw-instnc-rl", self.nextflow_role
         )


### PR DESCRIPTION
# TO TEST
This is currently deployed. Try running the lambda function `ccd-pvsl-dapq-sqslmbdtrgfnct-c30b38c` with an event of type SQS and the following payload:

```
{
  "Records": [
    {
      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
      "receiptHandle": "MessageReceiptHandle",
      "body": "{\n\"pipeline_name\": \"bactopia 3.0.1 tutorial analysispipeline\",\n\"pipeline_version\": \"3.0.1\",\n\"input_path\": \"s3://input/blah/blah/blah\",\n\"output_path\": \"s3://output/blah/blah/blah\"\n}",
      "attributes": {
        "ApproximateReceiveCount": "1",
        "SentTimestamp": "1523232000000",
        "SenderId": "123456789012",
        "ApproximateFirstReceiveTimestamp": "1523232000001"
      },
      "messageAttributes": {},
      "md5OfBody": "{{{md5_of_body}}}",
      "eventSource": "aws:sqs",
      "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:MyQueue",
      "awsRegion": "us-east-1"
    }
  ]
}
```

You should get a log message for the lambda with a command id and no errors