### PR TITLE
EC2 Instance tagging for pipeline executors

### DIFF
--- a/assets/lambda/api-handlers/analysis-pipeline/list_analysis_pipelines.py
+++ b/assets/lambda/api-handlers/analysis-pipeline/list_analysis_pipelines.py
@@ -70,7 +70,7 @@ def get_dap_registry_table(table_name: str):
 
 
 def index_handler(event, context):
-    """Handler for the POST of a new analysis pipeline run.
+    """Handler for the GET of all available analysis pipelines.
 
     :param event: The event object that contains the HTTP request and json
                   data.

--- a/assets/lambda/api-handlers/analysis-pipeline/list_pipeline_executors.py
+++ b/assets/lambda/api-handlers/analysis-pipeline/list_pipeline_executors.py
@@ -1,0 +1,100 @@
+"""Lambda function for handling a post of a new analysis pipeline run."""
+
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+ec2_client = boto3.client("ec2")
+
+
+# TODO: ISSUE #86
+def decode_error(err: ClientError):
+    """Decode a ClientError from AWS.
+
+    Args:
+        err: The ClientError being decoded.
+
+    Returns:
+        A tuple containing the error code and the error message provided by AWS.
+    """
+    code, message = "Unknown", "Unknown"
+    if "Error" in err.response:
+        error = err.response["Error"]
+        if "Code" in error:
+            code = error["Code"]
+        if "Message" in error:
+            message = error["Message"]
+    return code, message
+
+
+def index_handler(event, context):
+    """Handler for the GET of available ec2 instances to executing pipelines.
+
+    :param event: The event object that contains the HTTP request and json
+                  data.
+    :param context: Context object.
+    """
+
+    try:
+        # get all pipeline executor instances
+        pipeline_executors = ec2_client.describe_instances(
+            Filters=[
+                {"Name": "tag:Pipeline", "Values": ["nextflow"]},
+                {"Name": "instance-state-name", "Values": ["running"]},
+            ]
+        )
+
+        # next, we really only want to return a few of the key/values for each
+        # item. so extract what we want:
+        resp_data = []
+        for reservation in pipeline_executors.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                names = [
+                    tag["Value"]
+                    for tag in instance["Tags"]
+                    if tag["Key"] == "Name"
+                ]
+                name = names[0] if names else None
+                resp_data.append(
+                    {"instanceId": instance["InstanceId"], "instanceName": name}
+                )
+
+        # And return our response as a 200
+        return {
+            "statusCode": 200,
+            "headers": {
+                "Content-Type": "application/json",
+                # TODO: ISSUE #141 CORS bypass. We do not want this long term.
+                #       When we get all the api and web resources on the same
+                #       domain, this may not matter too much. But we may
+                #       eventually end up with needing to handle requests from
+                #       one domain served up by another domain in a lambda
+                #       handler. In that case we'd need to be able to handle
+                #       CORS, and would want to look into allowing
+                #       configuration of the lambda (via pulumi config that
+                #       turns into env vars for the lambda) that set the
+                #       origins allowed for CORS.
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "OPTIONS,GET",
+            },
+            "body": json.dumps(resp_data),
+        }
+    except ClientError as err:
+        code, message = decode_error(err)
+
+        msg = (
+            f"Error during processing of available ec2 instances for pipeline "
+            f"execution. {code} {message}"
+        )
+        logger.exception(msg)
+
+        return {
+            "statusCode": 500,
+            "body": msg,
+        }

--- a/assets/lambda/api-handlers/analysis-pipeline/list_pipeline_executors.py
+++ b/assets/lambda/api-handlers/analysis-pipeline/list_pipeline_executors.py
@@ -59,9 +59,9 @@ def index_handler(event, context):
                 if "Pipeline" in tags:
                     resp_data.append(
                         {
-                            "instanceId": instance["InstanceId"],
-                            "instanceName": tags.get("Name", None),
-                            "pipelineType": tags["Pipeline"],
+                            "instance_id": instance["InstanceId"],
+                            "instance_name": tags.get("Name", None),
+                            "pipeline_type": tags["Pipeline"],
                         }
                     )
 

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -402,6 +402,15 @@ def get_dap_api_policy(queue_name: str, table_name: str):
                         f"arn:aws:dynamodb:*:*:table/{table_name}",
                     ],
                 },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ec2:DescribeInstances",
+                    ],
+                    "Resource": [
+                        "*",
+                    ],
+                },
             ],
         },
     )

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -618,8 +618,11 @@ def get_sqs_lambda_dap_submit_policy(queue_name: str, table_name: str) -> str:
                     "Action": "ec2:DescribeInstances",
                     # TODO: ISSUE #158
                     "Resource": [
-                        "arn:aws:ec2:us-east-2:767397883306:instance/*",
+                        "arn:aws:ec2:*:*:instance/*",
                     ],
+                    "Condition": {
+                        "Null": {"aws:ResourceTag/Pipeline": "false"}
+                    },
                 },
             ],
         },

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -181,6 +181,19 @@ class PrivateSwimlane(ScopedSwimlane):
                 "method": "GET",
                 "enable_cors": True,
             },
+            {
+                "name": "listexecutors",
+                "handler": "index.index_handler",
+                "runtime": "python3.11",
+                "handler_src": (
+                    "./assets/lambda/api-handlers/analysis-pipeline/"
+                    "list_pipeline_executors.py"
+                ),
+                "handler_vars": {},
+                "path_part": "pipelineexecutors",
+                "method": "GET",
+                "enable_cors": True,
+            },
         ]
 
         # tracks the methods and integrations we define below. without this


### PR DESCRIPTION
This restricts the pipeline execution policy for the analysis pipelines to only be able to send commands to EC2 instances tagged with "Pipeline". This also adds a `/pipelineexecutors` API endpoint for querying what EC2 instances are available and running that are valid for executing pipelines. Currently it will only retrieve Nextflow pipeline executing ec2 instances as well as ec2 instances can only be tagged to execute one single type of pipeline. This could be expanded to support comma delimited strings, also the pipeline type could be passed as a GET parameter to retrieve only pipelines of a specific type.

Closes #158