### PR TITLE
fix integrationHttpMethod always showing change for options endpoints

### DIFF
--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -312,7 +312,6 @@ class PrivateSwimlane(ScopedSwimlane):
                     type="MOCK",
                     resource_id=handler_resource.id,
                     rest_api=self.dap_rest_api.id,
-                    integration_http_method="OPTIONS",
                     request_templates={
                         "application/json": "{'statusCode':200}"
                     },
@@ -325,7 +324,7 @@ class PrivateSwimlane(ScopedSwimlane):
                     f"{self.basename}-dapapi-{short_name}-options-intgrsp",
                     rest_api=self.dap_rest_api.id,
                     resource_id=handler_resource.id,
-                    http_method="OPTIONS",
+                    http_method=options_method.http_method,
                     status_code="200",
                     response_parameters={
                         "method.response.header.Access-Control-Allow-Headers": (

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -295,7 +295,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
                 opts_integration = aws.apigateway.Integration(
                     f"{self.basename}-dapapi-{short_name}-options-intg",
-                    http_method="OPTIONS",
+                    http_method=options_method.http_method,
                     type="MOCK",
                     resource_id=handler_resource.id,
                     rest_api=self.dap_rest_api.id,


### PR DESCRIPTION
# TO TEST
Once this has been deployed once (which it should be already), `pulumi preview` should not show changes for options `integrationHttpMethod`s anymore (unless there are real changes to it). 