### PR TITLE
Swapped out host-specific cert/key for wildcard version

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -99,8 +99,8 @@ config:
                       # named following the pattern {fqdn}.[key|crt] where
                       # `{fqdn}` is the value of the fqdn provided in the above
                       # static_app scope
-                      server-key: "analysis-pipelines.cape-dev.org.key"
-                      server-cert: "analysis-pipelines.cape-dev.org.crt"
+                      server-key: "*.cape-dev.org.key"
+                      server-cert: "*.cape-dev.org.crt"
                   # repo_dir is the root directory in the repo for this app's
                   # files.
                   # TODO: long-term we will not want to have these apps in the


### PR DESCRIPTION
This PR contains a simple change to the config, but goes with new wildcard certs that are not in the repo. This has been deployed, but you will need to update your `assets/untracked/tls/dap-ui` files to match so future deployments do not fail.

# TO TEST
* As this has already been deployed, testing is just making sure that the files are what we think and that the sites protected by the certs are still accessible.
  * Go into ACM manager in AWS and ensure we have 2 certs. One for domain `server` (this is the horribly named VPN cert) and one for domain `*.cape-dev.org` (this is the new one for the PVSL ALBs
  * get on the VPN (there's a new config if you haven't updated since 2024.10.22) and hit `https://analysis-pipelines.cape-dev.org/dap-ui` and make sure the page loads. In whatever manner your browser allows you to look at the server cert info, make sure the cert is issued to the Common Name (CN)  `*.cape-dev.org` and is issued by the Common Name (CN) `cape-dev.org` (no asterisk in this one)
* Approve PR
