### PR TITLE
142 move dap api behind alb and route53

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -3,10 +3,10 @@ config:
     # This block is for meta about the deployment itself that may be reused in
     # later config settings.
     deployment:meta: &depmet
-        # stage-name is used anywhere we need the deployment stage name and
+        # stage-suffix is used anywhere we need the deployment stage name and
         # should be values like "dev", "prod", etc. There is exact no exact
         # enumeration of values yet.
-        stage-name: "dev"
+        stage-suffix: "dev"
     aws:region: us-east-2
     cape-cod:meta:
         glue:
@@ -89,8 +89,34 @@ config:
             #       things. for now just trying to get the stage name
             #       configurable from the root deployment:meta section
             api:
-                dap:
+                # all apis will go in the same subdomain, and will be
+                # differentiated based on the path component of each individual
+                # api in the list below. e.g. for a domain of cape-dev.org and a
+                # subdomain value of "api", all apis will be rooted at
+                # api.cape-dev.org. for an api named `api1` and a stage-name of
+                # `dev`, that specific api can be found at
+                # api.cape-dev.org/api1-dev
+                subdomain: "api"
+                # this item needs to exist as-is. we have a common stage suffix
+                # used for all apis in the dpeloyment at present, and this is
+                # how we access it
+                stage:
                     meta: *depmet
+                apis:
+                    # for every item in this list will specify an individual
+                    # api to be deployed. each item should have:
+                    #   - name: a short, unique identifier for this api that
+                    #           will be used in resource names and descriptions
+                    #   - stage_name: the stage name that the api will be
+                    #                 deployed to. NOTE: this *does not*
+                    #                 include the stage suffix, but will
+                    #                 include it once deployed.
+                    #   - desc: A description for the api. Will be used in
+                    #           description tags.
+                    # TODO: ISSUE #61 - openapi spec file would go here
+                    - name: "dapapi"
+                      stage_name: "dap"
+                      desc: "Data Analysis Pipeline API"
             # static apps are deployed to s3 as html/js/css bundles and are
             # exposed through an application load balancer. these may hit API
             # endpoints (assuming the required permissions/roles are available),

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -103,20 +103,14 @@ config:
                 stage:
                     meta: *depmet
                 apis:
-                    # for every item in this list will specify an individual
-                    # api to be deployed. each item should have:
-                    #   - name: a short, unique identifier for this api that
-                    #           will be used in resource names and descriptions
-                    #   - stage_name: the stage name that the api will be
-                    #                 deployed to. NOTE: this *does not*
-                    #                 include the stage suffix, but will
-                    #                 include it once deployed.
+                    # Every element in this object will specify an individual
+                    # api to be deployed. Where the key is the api name and
+                    # each item should have:
                     #   - desc: A description for the api. Will be used in
                     #           description tags.
                     # TODO: ISSUE #61 - openapi spec file would go here
-                    - name: "dapapi"
-                      stage_name: "dap"
-                      desc: "Data Analysis Pipeline API"
+                    dap:
+                        desc: "Data Analysis Pipeline API"
             # static apps are deployed to s3 as html/js/css bundles and are
             # exposed through an application load balancer. these may hit API
             # endpoints (assuming the required permissions/roles are available),

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -34,8 +34,8 @@ config:
                   srcpth: ./assets/etl/etl_bactopia_results.py
     cape-cod:swimlanes:
         private:
-            # This is the private domain that will setup in the cloud provider
-            # private VPC.
+            # This is the private domain that will be setup in the cloud
+            # provider private VPC.
             # At this time, this does not need to be setup with a domain
             # registrar unless it is also the domain used in a public facing
             # resource. The domain will need to be able to be used for creation
@@ -43,9 +43,17 @@ config:
             # self-signed and in all cases need to be managed outside this
             # repo).
             domain: cape-dev.org
-            # TODO: This is huge. way bigger than we need. For growth but also
-            # cause we don't really know what address space we need yet. Adjust
-            # as needed
+            # NOTE: at this time we support a single (wildcard) cert per
+            #       swimlane for non-vpn tls/ssl (vpn has its own cert). this
+            #       may change in the future
+            tls:
+                dir: "./assets-untracked/tls/private-swimlane"
+                ca-cert: "ca.crt"
+                # if not specified, the key and cert are expected to be
+                # named following the pattern {fqdn}.[key|crt] where
+                # `{fqdn}` is the value of the domain key provided above
+                server-key: "*.cape-dev.org.key"
+                server-cert: "*.cape-dev.org.crt"
             cidr-block: 10.0.0.0/16
             public-subnet:
                 # public subnet is special and there will be one (for now) per
@@ -92,15 +100,6 @@ config:
             static-apps:
                 - name: "dap-ui"
                   fqdn: "analysis-pipelines.cape-dev.org"
-                  tls:
-                      dir: "./assets-untracked/tls/dap-ui"
-                      ca-cert: "ca.crt"
-                      # if not specified, the key and cert are expected to be
-                      # named following the pattern {fqdn}.[key|crt] where
-                      # `{fqdn}` is the value of the fqdn provided in the above
-                      # static_app scope
-                      server-key: "*.cape-dev.org.key"
-                      server-cert: "*.cape-dev.org.crt"
                   # repo_dir is the root directory in the repo for this app's
                   # files.
                   # TODO: long-term we will not want to have these apps in the

--- a/capeinfra/resources/loadbalancer.py
+++ b/capeinfra/resources/loadbalancer.py
@@ -466,7 +466,6 @@ class AppLoadBalancer(CapeComponentResource):
         self,
         vpc_ep: aws.ec2.VpcEndpoint,
         api_stage_name: str,
-        # TODO: remove stage id
         port: int | None = 443,
         proto: str | None = "HTTPS",
     ):

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -334,7 +334,8 @@ class ScopedSwimlane(CapeComponentResource):
 
         Args:
             record_name: The record name (e.g. subdomain.domain.tld).
-            short_name: A short, unique name for the record.
+            short_name: A short, unique name for the record. This is only used
+                        in the resource name.
             alb_id: The identifier string of the ALB to associate the record
                     with.
             aliases: A list of dicts containing alias args for the record. The

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -883,6 +883,10 @@ class PrivateSwimlane(ScopedSwimlane):
                 sa_info["bucket"].bucket.bucket, sa_name, "static"
             )
 
+        # TODO: need this based on config
+        self.create_private_domain_alb_record(
+            "api.cape-dev.org", "dapapi", "api"
+        )
         # and DNS for the zone
         self.create_private_hosted_dns(
             [self.private_subnets["vpn"], self.private_subnets["vpn2"]]


### PR DESCRIPTION
# TO TEST

This has been deployed and tested to make sure API endpoints are available via custom domain name within the VPN. A custom build of the UI has also been put out there with the new custom domains for the api.

Best way to test is to get on the VPN and use the UI to make sure it has only 200's for our custom domains and to also hit the api endpoint with curl. format:

`curl -k https://api.cape-dev.org/dap-dev/analysispipelines`