### PR TITLE
131 remove need to know vpnvpn2 subnets by name

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1,3 +1,16 @@
+# extensions for constant reusable values. these are *not* direct config values
+# for pulumi, but are used in various sections. changing the value here will
+# change all usages of the anchors elsewhere
+
+# availability zone 1
+x-az-1: &az1
+    az: "us-east-2b"
+# availability zone 2
+x-az-2: &az2
+    az: "us-east-2c"
+
+# actual config follows
+
 # `encryptionsalt` (string, required)
 # This key is added and managed by pulumi. this should not be modified outside
 # of that context, and is specific to your pulumi setup
@@ -179,15 +192,19 @@ config:
                   type: compute
                   routes:
                       - "public"
+                # - name: vpnaz1
                 - name: vpn
                   cidr-block: 10.0.3.0/24
-                  az: "us-east-2b"
+                  # az: "us-east-2b"
+                  <<: *az1
                   type: vpn
                   routes:
                       - "public"
+                # - name: vpnaz2
                 - name: vpn2
                   cidr-block: 10.0.4.0/24
-                  az: "us-east-2c"
+                  <<: *az2
+                  #az: "us-east-2c"
                   type: vpn
                   routes:
                       - "public"

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -150,7 +150,7 @@ config:
             #     time, but the name is reserved for the future
             #   * `vpn`: any subnet marks as the VPN type will be configured to
             #     be a target of the external client VPN setup.
-            # * `make_public`: (boolean, optional)
+            # * `public`: (boolean, optional)
             #   A boolean stating if the subnet should be made public (have an
             #   associated public IP address). This defaults to False. In the
             #   CAPE reference architecture, only subnets of type `nat` are
@@ -186,7 +186,7 @@ config:
                 - name: public
                   cidr-block: 10.0.1.0/24
                   type: nat
-                  make_public: True
+                  public: True
                   <<: *az1
                 - name: compute
                   cidr-block: 10.0.2.0/24

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -187,24 +187,22 @@ config:
                   cidr-block: 10.0.1.0/24
                   type: nat
                   make_public: True
+                  <<: *az1
                 - name: compute
                   cidr-block: 10.0.2.0/24
                   type: compute
+                  <<: *az1
                   routes:
                       - "public"
-                # - name: vpnaz1
-                - name: vpn
+                - name: vpnaz1
                   cidr-block: 10.0.3.0/24
-                  # az: "us-east-2b"
                   <<: *az1
                   type: vpn
                   routes:
                       - "public"
-                # - name: vpnaz2
-                - name: vpn2
+                - name: vpnaz2
                   cidr-block: 10.0.4.0/24
                   <<: *az2
-                  #az: "us-east-2c"
                   type: vpn
                   routes:
                       - "public"

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -124,13 +124,33 @@ config:
             #   for ISSUE #131 below)
             # * `cidr-block` (string, required)
             #   The cidr block given to the subnet
+            # * `type`: (string, required)
+            #   a string representing the type of subnet. some types are
+            #   special and they're strings are reserved. known types are:
+            #   * `nat`: the subnet will be given a nat gateway. at present,
+            #     this gateway will be an internet gateway and the NAT will be
+            #     for internet egress. no other gateways are yet supported
+            #     (meaning no private NAT)
+            #   * `compute`: there is no special handling for this type at this
+            #     time, but the name is reserved for the future
+            #   * `app`: there is no special handling for this type at this
+            #     time, but the name is reserved for the future
+            #   * `vpn`: any subnet marks as the VPN type will be configured to
+            #     be a target of the external client VPN setup.
+            # * `make_public`: (boolean, optional)
+            #   A boolean stating if the subnet should be made public (have an
+            #   associated public IP address). This defaults to False. In the
+            #   CAPE reference architecture, only subnets of type `nat` are
+            #   configured as public. If there is not an explicit need for a
+            #   subnet to be public (and then only if you understand the
+            #   security implications) then the subnet should be kept private
             # * `routes` (string[], optional)
             #   A list of subnet names for which this subnet should be able to
             #   route to (via routing table). The special name "public" may be
             #   used to allow routing to the public subnet for the swimlane (if
             #   public is not explicitly specified, the subnet will have no
             #   internet access).
-            # * `az` (string optional)
+            # * `az` (string, optional)
             #   An explicit availability zone for the subnet. If not provided,
             #   the default availability zone will be used. This is generally
             #   only needed when setting up redundant private subnets for
@@ -147,20 +167,28 @@ config:
             # We will be redoing the subnet addressing in the near future (after
             # #109 and #131)
             subnets:
+                # TODO: name being left 'public' for now to make sure typing
+                #       doesn't introduce `pulumi preview` changes. we don't
+                #       want to leave the name `public` forever though
                 - name: public
                   cidr-block: 10.0.1.0/24
+                  type: nat
+                  make_public: True
                 - name: compute
                   cidr-block: 10.0.2.0/24
+                  type: compute
                   routes:
                       - "public"
                 - name: vpn
                   cidr-block: 10.0.3.0/24
                   az: "us-east-2b"
+                  type: vpn
                   routes:
                       - "public"
                 - name: vpn2
                   cidr-block: 10.0.4.0/24
                   az: "us-east-2c"
+                  type: vpn
                   routes:
                       - "public"
             # `api` (mapping, optional)

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -163,7 +163,7 @@ config:
             #   used to allow routing to the public subnet for the swimlane (if
             #   public is not explicitly specified, the subnet will have no
             #   internet access).
-            # * `az` (string, optional)
+            # * `az` (string, required)
             #   An explicit availability zone for the subnet. If not provided,
             #   the default availability zone will be used. This is generally
             #   only needed when setting up redundant private subnets for
@@ -205,6 +205,10 @@ config:
                   <<: *az2
                   type: vpn
                   routes:
+                      # TODO: ISSUE #118
+                      # this is currently routing the vpn subnet in az2 to the
+                      # nat in az1. when we redo the network in #118 we need to
+                      # change this route to be to the az2 nat subnet
                       - "public"
             # `api` (mapping, optional)
             # Contains the configuration for apis and the API application load

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -1,7 +1,7 @@
 """Module for swimlane related abstractions."""
 
 from abc import abstractmethod
-from enum import StrEnum, auto
+from enum import Enum
 from typing import Any
 
 import pulumi_aws as aws
@@ -18,7 +18,7 @@ from capepulumi import CapeComponentResource, CapeConfig
 
 
 # TODO: ISSUE #198
-class SubnetType(StrEnum):
+class SubnetType(str, Enum):
     """Enum of all reserved subnet types for a swimlane.
 
     The order of members of the enum is important. At a minimum it implies the
@@ -37,10 +37,10 @@ class SubnetType(StrEnum):
                  the name is reserved for the future
     """
 
-    NAT = auto()
-    VPN = auto()
-    COMPUTE = auto()
-    APP = auto()
+    NAT = "nat"
+    VPN = "vpn"
+    COMPUTE = "compute"
+    APP = "app"
 
 
 class ScopedSwimlane(CapeComponentResource):

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -1,7 +1,7 @@
 """Module for swimlane related abstractions."""
 
 from abc import abstractmethod
-from enum import StrEnum
+from enum import StrEnum, auto
 from typing import Any
 
 import pulumi_aws as aws
@@ -17,26 +17,30 @@ from capeinfra.util.naming import disemvowel
 from capepulumi import CapeComponentResource, CapeConfig
 
 
+# TODO: ISSUE #198
 class SubnetType(StrEnum):
     """Enum of all reserved subnet types for a swimlane.
+
+    The order of members of the enum is important. At a minimum it implies the
+    order the subnets should be created in.
 
     Types are as follows:
         * `nat`: the subnet will be given a nat gateway. at present, this
                  this gateway will be an internet gateway and the NAT will be
                  for internet egress. no other gateways are yet supported
                  (meaning no private NAT)
+        * `vpn`: any subnet marked as the VPN type will be configured to be a
+                 target of the external client VPN setup.
         * `compute`: there is no special handling for this type at this time,
                      but the name is reserved for the future
         * `app`: there is no special handling for this type at this time, but
                  the name is reserved for the future
-        * `vpn`: any subnet marked as the VPN type will be configured to be a
-                 target of the external client VPN setup.
     """
 
-    nat = "nat"
-    compute = "compute"
-    vpn = "vpn"
-    app = "app"
+    NAT = auto()
+    VPN = auto()
+    COMPUTE = auto()
+    APP = auto()
 
 
 class ScopedSwimlane(CapeComponentResource):
@@ -67,6 +71,11 @@ class ScopedSwimlane(CapeComponentResource):
         # self.subnets keys are subnet names and values are tuples of subnet
         # type (str) and subnet object (aws.ec2.Subnet)
         self.subnets = dict[str, tuple[str, aws.ec2.Subnet]]()
+        # self.az_assets keys are availability zone strings and values are
+        # dicts of assets used in that az that other resources may need access
+        # to. e.g. self.az_assets["us-east-2b"]["inet_nat_gw"] is the internet
+        # facing nat gateway for az "us=east-2b"
+        self.az_assets = dict[str, dict[str, Any]]()
         self.compute_environments = dict[str, BatchCompute]()
         self.albs = {}
         self.domain_name = self.config.get("domain")
@@ -176,74 +185,244 @@ class ScopedSwimlane(CapeComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-    def _create_public_subnet(self, cidr_block: str, sn_type: str):
-        """Default implementation of public subnet creation for a swimlane.
+    # TODO: ISSUE #198
+    def _setup_nat_subnet(
+        self, basename: str, az: str, routes: list, subnet: aws.ec2.Subnet
+    ):
+        """Associate the given subnet with a NAT GW pointed at an internet GW.
 
-        The default implementation sets up the subnet as configured and adds a
-        NAT gateway for private subnet instances to send requests to the
-        internet. Additionally all outgoing traffic is routed to the swimlane's
-        internet gateway.
+        No check is made that this subnet is in fact public facing. The NAT GW
+        is setup for internet egress only.
 
         Args:
-            cidr_block: The cidr block for the public subnet
+            basename: The string to use as the base for the resource names
+            az: The name of the availability zone to create the nat in.
+            subnet: The subnet to associate with an internet facing NAT GW.
+        Returns:
+            A new list of routes for the subent with the internet egress route
+            first in the list.
         """
-        pubsn_name = f"{self.vpc_name}-pubsn"
-        public_subnet = aws.ec2.Subnet(
-            pubsn_name,
-            vpc_id=self.vpc.id,
-            cidr_block=cidr_block,
-            map_public_ip_on_launch=True,
-            tags={
-                "Name": pubsn_name,
-                "desc_name": f"{self.desc_name} public subnet",
-            },
-        )
 
-        eip = aws.ec2.Eip(f"{self.vpc_name}-nat-eip")
+        eip = aws.ec2.Eip(f"{basename}-nateip")
 
-        self.nat_gateway = aws.ec2.NatGateway(
-            f"{self.vpc_name}-natgw",
-            subnet_id=public_subnet.id,
+        nat_gateway = aws.ec2.NatGateway(
+            f"{basename}-natgw",
+            subnet_id=subnet.id,
             allocation_id=eip.id,
         )
 
-        public_rt = aws.ec2.RouteTable(
-            f"{pubsn_name}-rt",
-            vpc_id=self.vpc.id,
-            routes=[
-                {
-                    # all outgoing traffic in the public subnet goes to the
-                    # internet gateway
-                    "cidr_block": "0.0.0.0/0",
-                    "gateway_id": self.internet_gateway.id,
-                }
-            ],
-        )
+        # we want to return a new list of routes with the internet egress route
+        # being first, and all routes we were given initially after that
+        nat_sn_routes = [
+            {
+                # all outgoing traffic in the public subnet goes to the
+                # internet gateway
+                "cidr_block": "0.0.0.0/0",
+                "gateway_id": self.internet_gateway.id,
+            }
+        ]
 
-        aws.ec2.RouteTableAssociation(
-            f"{pubsn_name}-rtassn",
-            subnet_id=public_subnet.id,
-            route_table_id=public_rt.id,
-        )
+        nat_sn_routes.extend(routes)
 
-        self.subnets["public"] = (sn_type, public_subnet)
+        # NOTE: this is a little bit obnoxious. we pass in the AZ string to
+        #       this method even though we should have access to it via the
+        #       subnet object. reason being is that it's an Output property
+        #       on the subnet, and if we use it as a key into az_assets (using
+        #       apply()) it might not be resolved by the time we create another
+        #       subnet that needs to route to it. so we bypass the resolution
+        #       time by passing in a string that we know will exist when needed
+        self.az_assets.setdefault(az, {}).setdefault("inet_nat_gw", nat_gateway)
 
-    def _check_subnet_configs(self, sn_configs: dict[str, dict[str, Any]]):
+        return nat_sn_routes
+
+    # TODO: ISSUE #198
+    def _check_subnet_configs(
+        self,
+        sn_configs: dict[str, dict[str, Any]],
+        required_keys: list[str] = ["az"],
+    ):
         """Check the subnet configuration values for baseline requirements.
+
+        By default, we require an AZ to be specified for all subnets. We are
+        not checking the validity of the az, nor that redundant subnets are
+        in different AZs or anything else like that. In the event that a
+        subclass overrides this default implementation, 'az' needs to be
+        included or there could be issues in subnet creation.
 
         Args:
             sn_configs: A dict of subnet config dicts keyed on subnet name.
+            required_keys: A list of required config keys. If any are missing,
+                           deployment will halt due to a KeyError
+        Raises:
+            KeyError: on missing required config key.
         """
 
         for name, cfg in sn_configs.items():
-            # we require an AZ to be specified for all subnets. we are not
-            # checking the validity of the az, nor that redundant subnets
-            # are in different AZs or anything else like that. maybe one day
-            if "az" not in cfg:
-                raise KeyError(
-                    f"Config for subnet {name} does not contain required key "
-                    "'az'"
+            for rq in required_keys:
+                if rq not in cfg:
+                    raise KeyError(
+                        f"Config for subnet {name} does not contain required key "
+                        f"'{rq}'"
+                    )
+
+    # TODO: ISSUE #198
+    def _resolve_subnet_dependencies(
+        self, sn_configs: dict[str, dict[str, Any]]
+    ):
+        """Return creation-ordered dict of {name:subnet_config}.
+
+        This is a very naive implementation of a dependency resolver. Right now
+        we just ensure order based on subnet type, with nat subnets being
+        handled first as we need their nat gateways available for internet
+        egress for other subnets.
+
+        Args:
+            sn_configs: Unordered dict of format {sn_name: sn_config}.
+        Returns:
+            A dict who's insertion order is the order in which subnets should be
+            created.
+        """
+        ordered_subnet_configs = {}
+        processed_keys = []
+
+        # SubnetType members are in the order we're going to create subnets in.
+        # As we use a string enum for that, we can't really sort the items based
+        # on the enum as it wants to use lexicographical sort. We could make
+        # ge/le methods in the enum class to support that i guess, but we could
+        # also just accept a small performance hit for multiple loops here as
+        # it will just slow the deployment down by a tad. In reality we may
+        # come up with a better dependency resolution algo anyway that could
+        # make any optimizaion done now useless anyway. So multiple loops it
+        # is...
+
+        # first insert all the subnets with known types from our enumeration
+        # NOTE: the for...in here is in the order we want due to how SubnetType
+        #       is created. Don't go mucking with the order of types.
+        for sn_type in SubnetType:
+            for sn_name, sn_cfg in sn_configs.items():
+                if sn_type == sn_cfg.get("type", None):
+                    ordered_subnet_configs[sn_name] = sn_cfg
+                    processed_keys.append(sn_name)
+
+        # now add everything else that has a type we don't know about
+        ordered_subnet_configs.update(
+            {k: v for k, v in sn_configs.items() if k not in processed_keys}
+        )
+
+        # and return the sorted dict
+        return ordered_subnet_configs
+
+    # TODO: ISSUE #198
+    def _create_route_list(self, sn_name: str, rte_cfgs: dict[str, dict]):
+        """Return a list of routes formatted for creating a route table.
+
+        Args:
+            sn_name: The name of the subnet the routes are being created for.
+            rte_cfgs: A dict of the form {subnet_cfg_name: subnet_cfg} used for
+                      creating routes based on names from the config file.
+        Returns:
+            A list of dicts containing cidr_block and a an id of a gateway to
+            route to. This will have a different key based on if the gateway is
+            a NAT (`nat_gateway_id`) or another subnet (`gateway_id`).
+        """
+
+        routes = []
+
+        for rte, rcfg in rte_cfgs.items():
+            if rcfg is None:
+                warn(
+                    f"Subnet {sn_name} is configured to have a route to "
+                    f"a subnet ({rte}) that is not found. This route will "
+                    "be ignored."
                 )
+                continue
+            # NOTE: special handling for the NAT routes. we
+            #       assume in this case we're reouting all traffic to the
+            #       NAT. this may be a bad assumption in the future
+            if rcfg["type"] == SubnetType.NAT:
+                # in this case, we need to add a route to the nat gateway
+                # for the availiblity zone that routed to subnet is created
+                # in
+                # NOTE: this does allow a subnet in one AZ to route to a
+                #       subnet in a different AZ if configured that way.
+                routes.append(
+                    {
+                        # all outgoing traffic in the compute subnet goes to the
+                        # NAT gateway
+                        "cidr_block": "0.0.0.0/0",
+                        "nat_gateway_id": self.az_assets[rcfg["az"]][
+                            "inet_nat_gw"
+                        ].id,
+                    }
+                )
+            else:
+                # in this case we assume we're setting up a route from a
+                # private VPC subnet to another private VPC subnet, so local
+                # routing
+                routes.append(
+                    {
+                        "cidr_block": rcfg["cidr_block"],
+                        "gateway_id": "local",
+                    }
+                )
+
+        return routes
+
+    # TODO: ISSUE #198
+    def _create_subnet_route_table(
+        self, sn_res_name: str, routes: list, subnet: aws.ec2.Subnet
+    ):
+        """Create the route table for the subnet with the given routes list.
+
+        Args:
+            sn_res_name: The resource name of the subnet. Used as a prefix in
+                         ComponentResource naming.
+            routes: List of route definition dicts. Dicts contain a `cidr_block`
+                    item and a gateway id (with key depending on gateway type)
+                    to route traffic for that CIDR to.
+            subnet: The subnet object the route table is being constructed for.
+        """
+        subnet_rt = aws.ec2.RouteTable(
+            f"{sn_res_name}-rt",
+            vpc_id=self.vpc.id,
+            routes=routes,
+        )
+
+        aws.ec2.RouteTableAssociation(
+            f"{sn_res_name}-rtassn",
+            subnet_id=subnet.id,
+            route_table_id=subnet_rt.id,
+        )
+
+    # TODO: ISSUE #198
+    def _setup_subnet(
+        self,
+        sn_res_name: str,
+        sn_cfg: dict[str, Any],
+        rte_cfgs: dict[str, dict],
+        subnet: aws.ec2.Subnet,
+    ):
+        """Handle setup and routing for subnet types.
+
+        Only NAT subnets are currently handled specially.
+
+        Args:
+            sn_type: The type of subnet being handled.
+            sn_res_name: The resource name of the subnet.
+            az: The availability zone the subnet is being configured in.
+            subnet: The subnet object requiring special setup.
+        """
+
+        routes = self._create_route_list(sn_cfg["name"], rte_cfgs)
+
+        if sn_cfg["type"] == SubnetType.NAT:
+            # add a NAT gateway and get a new list of routes that includes
+            # routing to the nat
+            routes = self._setup_nat_subnet(
+                sn_res_name, sn_cfg["az"], routes, subnet
+            )
+
+        self._create_subnet_route_table(sn_res_name, routes, subnet)
 
     def create_subnets(self):
         """Default implementation of private subnet creation for a swimlane.
@@ -254,93 +433,61 @@ class ScopedSwimlane(CapeComponentResource):
         """
 
         # we need this to create a lookup for route configuration in addition
-        # to iteration below...
+        # to iteration below. we will need to create the nat (public) subnets
+        # first as we will need their nat gateway ids for any other subnets
+        # requiring agress to the internet
         named_pscs = {
             psnc["name"]: psnc
             for psnc in self.config.get("subnets", default=[])
         }
 
-        # TODO: ISSUE #131
-        # During issue #131 this should be refactored to have the common code
-        # shared between create_public_subnet and this method combined. Took
-        # the shortcut of leaving create_public_subnet as-is during
-        # implementation of #109. this change will probably lead to the name of
-        # the public subnet changing, which will be a difference in `pulumi
-        # preview`, avoiding that for now.
-        # During this change, keep in mind that the public subnet must be
-        # created first (as other subnets will need to route to the nat
-        # gateway). We will also need to support multiple public subnets (e.g.
-        # one per az)
-        # TODO: during ISSUE #131, handle the make_public config option
-        #       (defaults to False) and make AZ required
-
         # make sure subnets meet baseline to continue
         self._check_subnet_configs(named_pscs)
 
-        pub_sn_cfg = named_pscs.pop("public")
-        self._create_public_subnet(pub_sn_cfg["cidr-block"], pub_sn_cfg["type"])
+        # get an ordered version of this dict so that we can make the subnets in
+        # an order without dependency issues
+
+        ordered_pscs = self._resolve_subnet_dependencies(named_pscs)
 
         # TODO: ISSUE #118
-        for psnc in self.config.get("subnets", default=[]):
-            # TODO: ISSUE #131
-            # temp bypass of public subnet since it was handled above
-            if psnc["name"] == "public":
-                continue
+        for sn_name, sn_cfg in ordered_pscs.items():
+            sn_cfg = CapeConfig(sn_cfg)
 
-            psnc = CapeConfig(psnc)
-            config_sn_name = psnc.get("name")
             # devowel the configured name to try to save some characters in max
-            # string lengths for identifiers when constructing the subnet name
-            sn_name = f"{self.basename}-{disemvowel(config_sn_name)}sn"
+            # string lengths for identifiers when constructing the subnet
+            # resource name
+            sn_res_name = f"{self.basename}-{disemvowel(sn_name)}sn"
+
+            # Unless specified as True, subnets will be private
+            is_public = sn_cfg.get("make_public", False)
+
+            # TODO: ISSUE #198
             subnet = aws.ec2.Subnet(
-                sn_name,
-                cidr_block=psnc.get("cidr-block"),
+                sn_res_name,
+                # TODO: ISSUE #198
+                cidr_block=sn_cfg.get("cidr-block"),
                 vpc_id=self.vpc.id,
-                availability_zone=psnc.get("az"),
+                availability_zone=sn_cfg.get("az"),
+                map_public_ip_on_launch=is_public,
                 tags={
-                    "Name": sn_name,
-                    "desc_name": f"{self.desc_name} analysis {sn_name} subnet",
+                    "Name": f"{sn_res_name} ({sn_name})",
+                    "desc_name": (
+                        f"{self.desc_name} {sn_name} ("
+                        f"{'public' if is_public else 'private'} "
+                        f"{sn_cfg['type']}) subnet"
+                    ),
                 },
             )
 
-            routes = []
-            for rte in psnc.get("routes", default=[]):
-                # NOTE: special handling for the public subnet route. we
-                #       assume in this case we're reouting all traffic to the
-                #       NAT. this may be a bad assumption in the future
-                if rte == "public":
-                    routes.append(
-                        {
-                            # all outgoing traffic in the compute subnet goes to the
-                            # NAT gateway
-                            "cidr_block": "0.0.0.0/0",
-                            "nat_gateway_id": self.nat_gateway.id,
-                        }
-                    )
-                else:
-                    # in this case we assume we're setting up a route from a
-                    # private VPC subnet to another private VPC subnet, so local
-                    # routing
-                    routes.append(
-                        {
-                            "cidr_block": named_pscs[rte]["cidr_block"],
-                            "gateway_id": "local",
-                        }
-                    )
+            rte_cfgs = {}
 
-            subnet_rt = aws.ec2.RouteTable(
-                f"{sn_name}-rt",
-                vpc_id=self.vpc.id,
-                routes=routes,
-            )
+            for rte in sn_cfg.get("routes", default=[]):
+                rte_cfgs[rte] = ordered_pscs.get(rte, None)
 
-            aws.ec2.RouteTableAssociation(
-                f"{sn_name}-rtassn",
-                subnet_id=subnet.id,
-                route_table_id=subnet_rt.id,
-            )
+            # do any type-specific setup for the subnet
+            self._setup_subnet(sn_res_name, sn_cfg, rte_cfgs, subnet)
 
-            self.subnets[config_sn_name] = (psnc["type"], subnet)
+            self.subnets[sn_name] = (sn_cfg["type"], subnet)
 
     def create_compute_environments(self):
         """Default implementation of compute environment creation for a swimlane.
@@ -354,7 +501,7 @@ class ScopedSwimlane(CapeComponentResource):
             self.compute_environments[name] = BatchCompute(
                 name,
                 vpc=self.vpc,
-                subnets=self.get_subnets_by_type(SubnetType.compute),
+                subnets=self.get_subnets_by_type(SubnetType.COMPUTE),
                 config=env,
             )
 

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -464,7 +464,6 @@ class ScopedSwimlane(CapeComponentResource):
             # TODO: ISSUE #198
             subnet = aws.ec2.Subnet(
                 sn_res_name,
-                # TODO: ISSUE #198
                 cidr_block=sn_cfg.get("cidr-block"),
                 vpc_id=self.vpc.id,
                 availability_zone=sn_cfg.get("az"),

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -459,7 +459,7 @@ class ScopedSwimlane(CapeComponentResource):
             sn_res_name = f"{self.basename}-{disemvowel(sn_name)}sn"
 
             # Unless specified as True, subnets will be private
-            is_public = sn_cfg.get("make_public", False)
+            is_public = sn_cfg.get("public", False)
 
             # TODO: ISSUE #198
             subnet = aws.ec2.Subnet(

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -477,7 +477,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         self.create_alb(
             self.APPLICATION_ALB,
-            [s for _, s in self.get_subnets_by_type(SubnetType.vpn).items()],
+            [s for _, s in self.get_subnets_by_type(SubnetType.VPN).items()],
             self.domain_cert.acmcert,
         )
 
@@ -513,7 +513,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         self.create_alb(
             self.API_ALB,
-            [s for _, s in self.get_subnets_by_type(SubnetType.vpn).items()],
+            [s for _, s in self.get_subnets_by_type(SubnetType.VPN).items()],
             self.domain_cert.acmcert,
         )
 
@@ -545,7 +545,7 @@ class PrivateSwimlane(ScopedSwimlane):
             vpc_endpoint_type="Interface",
             subnet_ids=[
                 s.id
-                for _, s in self.get_subnets_by_type(SubnetType.vpn).items()
+                for _, s in self.get_subnets_by_type(SubnetType.VPN).items()
             ],
             # TODO: ISSUE #112
             tags={
@@ -624,7 +624,7 @@ class PrivateSwimlane(ScopedSwimlane):
             private_dns_enabled=True,
             subnet_ids=[
                 s.id
-                for _, s in self.get_subnets_by_type(SubnetType.vpn).items()
+                for _, s in self.get_subnets_by_type(SubnetType.VPN).items()
             ],
             # TODO: ISSUE #112
             tags={
@@ -802,7 +802,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         # and DNS for the zone
         self.create_private_hosted_dns(
-            [s for _, s in self.get_subnets_by_type(SubnetType.vpn).items()],
+            [s for _, s in self.get_subnets_by_type(SubnetType.VPN).items()],
         )
 
     # TODO: ISSUE #100
@@ -892,7 +892,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         # associate the VPN endpoint with all VPN subnets and setup auth
         # rules/routes for the vpn subnets
-        for sn_name, sn in self.get_subnets_by_type(SubnetType.vpn).items():
+        for sn_name, sn in self.get_subnets_by_type(SubnetType.VPN).items():
 
             # The client endpoint needs to be associated with one or more
             # subnets

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -32,7 +32,7 @@ from capeinfra.iam import (
 from capeinfra.resources.api import CapeRestApi
 from capeinfra.resources.certs import BYOCert
 from capeinfra.resources.objectstorage import VersionedBucket
-from capeinfra.swimlane import ScopedSwimlane
+from capeinfra.swimlane import ScopedSwimlane, SubnetType
 from capeinfra.util.file import file_as_string
 from capeinfra.util.jinja2 import get_j2_template_from_path
 from capeinfra.util.naming import disemvowel
@@ -477,10 +477,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         self.create_alb(
             self.APPLICATION_ALB,
-            [
-                self.subnets["vpn"],
-                self.subnets["vpn2"],
-            ],
+            [s for _, s in self.get_subnets_by_type(SubnetType.vpn).items()],
             self.domain_cert.acmcert,
         )
 
@@ -516,10 +513,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         self.create_alb(
             self.API_ALB,
-            [
-                self.subnets["vpn"],
-                self.subnets["vpn2"],
-            ],
+            [s for _, s in self.get_subnets_by_type(SubnetType.vpn).items()],
             self.domain_cert.acmcert,
         )
 
@@ -549,10 +543,9 @@ class PrivateSwimlane(ScopedSwimlane):
             vpc_id=self.vpc.id,
             service_name=f"com.amazonaws.{aws.get_region().name}.s3",
             vpc_endpoint_type="Interface",
-            # TODO: ISSUE #131
             subnet_ids=[
-                self.subnets["vpn"].id,
-                self.subnets["vpn2"].id,
+                s.id
+                for _, s in self.get_subnets_by_type(SubnetType.vpn).items()
             ],
             # TODO: ISSUE #112
             tags={
@@ -629,10 +622,9 @@ class PrivateSwimlane(ScopedSwimlane):
             service_name=f"com.amazonaws.{aws.get_region().name}.execute-api",
             vpc_endpoint_type="Interface",
             private_dns_enabled=True,
-            # TODO: ISSUE #131
             subnet_ids=[
-                self.subnets["vpn"].id,
-                self.subnets["vpn2"].id,
+                s.id
+                for _, s in self.get_subnets_by_type(SubnetType.vpn).items()
             ],
             # TODO: ISSUE #112
             tags={
@@ -734,13 +726,14 @@ class PrivateSwimlane(ScopedSwimlane):
 
             # now create the instance
             # TODO: ISSUE #184
+            _, subnet = self.subnets[aicfg["subnet_name"]]
             self.instance_apps[aicfg["name"]] = {
                 "instance": aws.ec2.Instance(
                     f"{self.basename}-{aicfg['name']}-ec2i",
                     ami=aicfg["image"],
                     associate_public_ip_address=aicfg.get("public_ip", False),
                     instance_type=aicfg.get("instance_type", "t3a.medium"),
-                    subnet_id=self.subnets[aicfg["subnet_name"]].id,
+                    subnet_id=subnet.id,
                     key_name=self.ec2inst_keypair.key_name,
                     # TODO: ISSUE #112
                     vpc_security_group_ids=[self.vpc.default_security_group_id],
@@ -809,7 +802,7 @@ class PrivateSwimlane(ScopedSwimlane):
 
         # and DNS for the zone
         self.create_private_hosted_dns(
-            [self.subnets["vpn"], self.subnets["vpn2"]]
+            [s for _, s in self.get_subnets_by_type(SubnetType.vpn).items()],
         )
 
     # TODO: ISSUE #100
@@ -886,13 +879,20 @@ class PrivateSwimlane(ScopedSwimlane):
             opts=ResourceOptions(parent=self),
         )
 
+        # LEFTOFF - this will cause name changes...
+        # TODO: we need this to happen for all vpn subnets, so this needs a
+        #       loop
+        _, vpn_subnet = self.subnets["vpn"]
+
         # The client endpoint needs to be associated with a subnet, so associate
         # it with the configured "vpn" subnet.
         # TODO: ISSUE #100
+        # TODO: need this (subnet assoc and authrules below) for every vpn
+        #       subnet, not just one
         subnet_association = aws.ec2clientvpn.NetworkAssociation(
             f"{self.basename}-vpnassctn",
             client_vpn_endpoint_id=self.client_vpn_endpoint.id,
-            subnet_id=self.subnets["vpn"].id,
+            subnet_id=vpn_subnet.id,
             opts=ResourceOptions(
                 depends_on=[self.client_vpn_endpoint],
                 parent=self.client_vpn_endpoint,
@@ -900,10 +900,10 @@ class PrivateSwimlane(ScopedSwimlane):
         )
 
         # By default, the client endpoint will get a route to the VPC itself. we
-        # need to also authorize the endpoint to route traffic to the VPN subnet
-        # and to the internet (through the VPN subnet). This requires an auth
-        # rule and a route for the internet case and just an auth rule for the
-        # VPN case
+        # need to also authorize the endpoint to route traffic to the VPN
+        # subnets and to the internet (through the VPN subnets). This requires
+        # an auth rule and a route for the internet case and just an auth rule
+        # for the VPN case
 
         # NOTE: leaving as 2 explicit auth rule creations instead of
         # trying to reduce DRY violation in a loop or something on purpose. Do
@@ -916,7 +916,7 @@ class PrivateSwimlane(ScopedSwimlane):
             client_vpn_endpoint_id=self.client_vpn_endpoint.id,
             # access vpn subnet only
             target_network_cidr=(
-                self.subnets["vpn"].cidr_block.apply(lambda cb: f"{cb}")
+                vpn_subnet.cidr_block.apply(lambda cb: f"{cb}")
             ),
             # access whole vpc
             # target_network_cidr=(self.vpc.cidr_block.apply(lambda cb: f"{cb}")),
@@ -942,7 +942,7 @@ class PrivateSwimlane(ScopedSwimlane):
             f"{self.basename}-inet-rt",
             client_vpn_endpoint_id=self.client_vpn_endpoint.id,
             destination_cidr_block="0.0.0.0/0",
-            target_vpc_subnet_id=self.subnets["vpn"].id,
+            target_vpc_subnet_id=vpn_subnet.id,
             opts=ResourceOptions(
                 depends_on=[subnet_association, auth_rule_inet]
             ),


### PR DESCRIPTION
# TO TEST

This has been deployed and can be inspected in AWS. Mainly we want to make sure everything still functions as it has for months. This deployment should have only changed some subnet names and given us types we can use instead of names when linking subnets and making routes/auth rules/etc.
