### PR TITLE
118 change our subnet configuration

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1,16 +1,3 @@
-# extensions for constant reusable values. these are *not* direct config values
-# for pulumi, but are used in various sections. changing the value here will
-# change all usages of the anchors elsewhere
-
-# availability zone 1
-x-az-1: &az1
-    az: "us-east-2b"
-# availability zone 2
-x-az-2: &az2
-    az: "us-east-2c"
-
-# actual config follows
-
 # `encryptionsalt` (string, required)
 # This key is added and managed by pulumi. this should not be modified outside
 # of that context, and is specific to your pulumi setup
@@ -34,6 +21,14 @@ config:
     # The AWS region the deployment will go into. As of now, CAPE supports a
     # single requion only
     aws:region: us-east-2
+    cape-cod:aws:
+        availability-zones:
+            # availability zone 1
+            az1: &az1
+                az: "us-east-2b"
+            # availability zone 2
+            az2: &az2
+                az: "us-east-2c"
     # `cape-cod:meta` (mapping, required)
     # Contains configuration that is used by a number of functional areas in
     # the deployment. E.g. a common s3 bucket where ETL scripts and Lambda

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -125,7 +125,7 @@ config:
                 server-cert: "*.cape-dev.org.crt"
             # `cidr-block` (string, optional)
             # The full cidr block that will be given to the private swimlane.
-            # Defaults to "10.0.0.0/24"
+            # Defaults to "10.0.0.0/24". Must be between /16 and /28
             cidr-block: 10.0.0.0/16
             # `subnets` (mapping[], optional)
             # A list of configurations for the private subnets of the swimlane.
@@ -133,8 +133,7 @@ config:
             # public subnet will be. All list items have the following schema:
             # * `name` (string, required)
             #   A short name for the subnet. This should be unique across all
-            #   subnets in the swimlane. The name "public" is special (see TODO
-            #   for ISSUE #131 below)
+            #   subnets in the swimlane.
             # * `cidr-block` (string, required)
             #   The cidr block given to the subnet
             # * `type`: (string, required)
@@ -168,48 +167,55 @@ config:
             #   the default availability zone will be used. This is generally
             #   only needed when setting up redundant private subnets for
             #   something like VPN
-            # TODO: ISSUE #131
-            # We need to change this up to have a type per subnet. Types should
-            # be used instead of names (such as vpn1/2 where we currently need
-            # to know the name of a subnet when defining resundant pairs in
-            # different az's). Additionally, until issue 131 is in, the name
-            # "public" is special. If not provided, a default public subnet
-            # configuration will be used. This is required to house a NAT for
-            # the VPC that allows traffic egress to the internet.
-            # TODO: ISSUE #118
-            # We will be redoing the subnet addressing in the near future (after
-            # #109 and #131)
             subnets:
-                # TODO: name being left 'public' for now to make sure typing
-                #       doesn't introduce `pulumi preview` changes. we don't
-                #       want to leave the name `public` forever though
-                - name: public
-                  cidr-block: 10.0.1.0/24
+                # AZ 1
+                - name: nataz1
+                  cidr-block: 10.0.127.0/24
                   type: nat
                   public: True
                   <<: *az1
-                - name: compute
-                  cidr-block: 10.0.2.0/24
+                - name: cmptaz1
+                  cidr-block: 10.0.0.0/20
                   type: compute
                   <<: *az1
                   routes:
-                      - "public"
+                      - "nataz1"
+                - name: appaz1
+                  cidr-block: 10.0.16.0/20
+                  type: app
+                  <<: *az1
+                  routes:
+                      - "nataz1"
                 - name: vpnaz1
-                  cidr-block: 10.0.3.0/24
+                  cidr-block: 10.0.120.0/22
                   <<: *az1
                   type: vpn
                   routes:
-                      - "public"
+                      - "nataz1"
+                # AZ 2
+                - name: nataz2
+                  cidr-block: 10.0.255.0/24
+                  type: nat
+                  public: True
+                  <<: *az2
+                - name: cmptaz2
+                  cidr-block: 10.0.128.0/20
+                  type: compute
+                  <<: *az2
+                  routes:
+                      - "nataz2"
+                - name: appaz2
+                  cidr-block: 10.0.144.0/20
+                  type: app
+                  <<: *az2
+                  routes:
+                      - "nataz2"
                 - name: vpnaz2
-                  cidr-block: 10.0.4.0/24
+                  cidr-block: 10.0.248.0/22
                   <<: *az2
                   type: vpn
                   routes:
-                      # TODO: ISSUE #118
-                      # this is currently routing the vpn subnet in az2 to the
-                      # nat in az1. when we redo the network in #118 we need to
-                      # change this route to be to the az2 nat subnet
-                      - "public"
+                      - "nataz2"
             # `api` (mapping, optional)
             # Contains the configuration for apis and the API application load
             # balancer. If this is not included, a default configuration will be
@@ -442,7 +448,8 @@ config:
                       image: "ami-05752f93029c09fa5"
                       public_ip: False
                       instance_type: "t3a.medium"
-                      subnet_name: "compute"
+                      subnet_types:
+                          - compute
                       subdomain: "jupyterhub"
                       port: 80
                       protocol: "HTTP"
@@ -480,7 +487,7 @@ config:
                 # More here:
                 # https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/scaling-considerations.html
                 # If not specified, this will default to "10.1.0.0/22"
-                cidr-block: "10.1.0.0/22"
+                cidr-block: "10.254.0.0/22"
                 # `transport-proto` (string, optional)
                 # Valid values are "tcp" and "udp". If not specified this will
                 # default to "udp"
@@ -554,7 +561,7 @@ config:
                 environments:
                     - name: analysis
                       image: ami-0cfe23bad78a802ea
-                      subnets:
+                      subnet_types:
                           - compute
                       resources:
                           instance_types:

--- a/capeinfra/pipeline/batch.py
+++ b/capeinfra/pipeline/batch.py
@@ -33,6 +33,10 @@ class BatchCompute(CapeComponentResource):
 
         Args:
             name: The name for the resource.
+            vpc: The VPC object the BatchCompute will be created for.
+            subnets: A dict of subnets names (from configuration) to subnet
+                     objects which are associated with the BatchCompute
+                     environment.
         Returns:
         """
         # This maintains parental relationships within the pulumi stack
@@ -99,13 +103,7 @@ class BatchCompute(CapeComponentResource):
 
         # self.key_pair = aws.ec2.KeyPair(f"{self.name}-kypr")
 
-        env_subnets = []
-        for subnet_name in self.config.get("subnets"):
-            subnet = subnets.get(subnet_name)
-            assert (
-                subnet is not None
-            ), f"Unknown subnet in compute environment {name}: {subnet_name}"
-            env_subnets.append(subnet.id)
+        env_subnets = [sn.id for _, sn in subnets.items()]
 
         self.compute_environment = aws.batch.ComputeEnvironment(
             f"{self.name}-btch",

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -449,7 +449,6 @@ class ScopedSwimlane(CapeComponentResource):
 
         ordered_pscs = self._resolve_subnet_dependencies(named_pscs)
 
-        # TODO: ISSUE #118
         for sn_name, sn_cfg in ordered_pscs.items():
             sn_cfg = CapeConfig(sn_cfg)
 
@@ -497,12 +496,13 @@ class ScopedSwimlane(CapeComponentResource):
         """
         for env in self.config.get("compute", "environments", default=[]):
             name = env.get("name")
-            self.compute_environments[name] = BatchCompute(
-                name,
-                vpc=self.vpc,
-                subnets=self.get_subnets_by_type(SubnetType.COMPUTE),
-                config=env,
-            )
+            for sn_type in env.get("subnet_types"):
+                self.compute_environments[name] = BatchCompute(
+                    name,
+                    vpc=self.vpc,
+                    subnets=self.get_subnets_by_type(sn_type),
+                    config=env,
+                )
 
     def create_hosted_domain(self, domain_name: str):
         """Create a private hosted domain for the swimlane.
@@ -540,7 +540,6 @@ class ScopedSwimlane(CapeComponentResource):
             direction="INBOUND",
             # TODO: ISSUE #112
             security_group_ids=[self.vpc.default_security_group_id],
-            # TODO: ISSUE #118
             ip_addresses=[
                 aws.route53.ResolverEndpointIpAddressArgs(subnet_id=sn.id)
                 for sn in subnets


### PR DESCRIPTION
# TO TEST
This has been deployed and can be checked out in AWS.

* Make sure we have 8 subnets and they match up to the diagram cidr-wise
* Make sure all load balancers (app and api) are now associated with the APP subnet (previously was vpn subnet)
* Make sure all TLJH EC2 instances are now associated with the APP subnet (previously was compute subnet)
* Make sure the batch compute env is associated with both compute subnets
* Log into VPN and make sure you can still access the API and UI for what we have had previously:
  * https://analysis-pipelines.cape-dev.org/index.html (pipeline UI)
  * https://api.cape-dev.org/dap-dev (api root)
  * https://api.cape-dev.org/dap-dev/analysispipelines (DAP api)
  * https://api.cape-dev.org/dap-dev/pipelineexecutors (executor api)
  * https://jupyterhub.cape-dev.org/ (JH)
* Do whatever else i might have missed adding here to test. You got this.