### PR TITLE
215 add api gateway test lambda authorizer

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -364,6 +364,7 @@ config:
                     dap:
                         desc: "Data Analysis Pipeline API"
                         spec_file: "assets/api/data-analysis-pipeline/dap-openapi-301.yaml.j2"
+                        authorizer: "assets/api/authz/default_apigw_authorizer.py"
                         env_vars:
                             - "DAP_QUEUE_NAME"
                             - "DAP_REG_DDB_TABLE"

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -320,6 +320,33 @@ config:
                 #   Path to an OpenApi 3.0.1 yaml specification jinja2
                 #   template. This file should include *no* AWS id's, names,
                 #   account info, etc.
+                # * `authorizers` (mapping, optional)
+                #   Configuration for authorizers for the API. In an OpenAPI
+                #   spec, all authorizers must be defined in the component
+                #   section, but may be applied at the API or endpoint levels.
+                #   The authorizer named "default" defined here will be applied
+                #   at the API level currently. Each mapping is keyed on an 
+                #   authorizor name (which must conform to AWS resource naming 
+                #   rules, and will be used as the base of a resource name, so 
+                #   it will be constrained in max length) and should contain:
+                #   * `file` (string, required)
+                #   Path (absolute or relative to repo root) to the file
+                #   containing the code for the authorizer lambda function
+                #   * `type` (string, required)
+                #   Type of lambda authorizer. Allowed values are "request", 
+                #   "token", or "cognito_user_pools".
+                #   * `identity_sources` (string[], optional)
+                #   List of strings of required query params or request headers
+                #   where identity information can be found. May be more than
+                #   one item.
+                #   * `result_cached_sec` (int, optional)
+                #   The number of seconds an authorization reqponse is cached
+                #   for. A value of 0 turns off caching (good for dev, bad for
+                #   prod). Defaults to 300.
+                #   * `logging_enabled` (bool, optional)
+                #   True if logging should be enabled for the authorizer, False
+                #   otherwise. The log stream will be in a log group specific to
+                #   the API.
                 # * `env_vars` (string[], optional)
                 #   A list of swimlane-exposed env vars that the API requires
                 #   access to. The env vars will be passed into the
@@ -364,7 +391,26 @@ config:
                     dap:
                         desc: "Data Analysis Pipeline API"
                         spec_file: "assets/api/data-analysis-pipeline/dap-openapi-301.yaml.j2"
-                        authorizer: "assets/api/authz/default_apigw_authorizer.py"
+                        # TODO: this is the default authorizer for the whole
+                        #       api. give it attrs like file, name, cache
+                        #       timeout, etc. probably want this to be a list of
+                        #       authorizers with one named default (that will be
+                        #       used for the whole api) and then others that
+                        #       individual handlers can override
+                        authorizers: 
+                            # `default` is a special name signifying the
+                            # authorizer that will be used for the whole api
+                            # barring any overrides at the endpoint level
+                            default:
+                                file: "assets/api/authz/default_apigw_authorizer.py"
+                                # allowed request, token, or cognito_user_pools
+                                type: "request"
+                                identity_sources: 
+                                # This is how long the authz result is cached. 0
+                                # turns off caching which is great for debug of
+                                # dev
+                                result_cached_sec: 0
+                                logging_enabled: True
                         env_vars:
                             - "DAP_QUEUE_NAME"
                             - "DAP_REG_DDB_TABLE"

--- a/assets/api/authz/default_apigw_authorizer.py
+++ b/assets/api/authz/default_apigw_authorizer.py
@@ -1,0 +1,81 @@
+# Basic lambda request authorizer for testing API gateway authz
+# TODO:
+# - once shown to work in basics, we should take this from test/sample status to
+#   a real authz implementation
+# - AWS docs suggest using request authorizers over token authorizers as the
+#   former can be used for finer grained policies and caching. we should figure
+#   out which better suits our needs, but for now we're following the advice.
+
+
+def lambda_handler(event, context):
+
+    # TODO: remove this debug printing
+    print(f"Lambda authz event: {event}")
+    print(f"Lambda authz context: {context}")
+
+    # figure out the caller from the request
+    # TODO: we can use headers, query string params, stage variables, path
+    #       parameters, and context variables to figure out who's calling. need
+    #       to figure out the best mix for all our services. client side (api
+    #       caller) has the ability to set path params, headers and query
+    #       params. all others are set by AWS
+
+    headers = event["headers"]
+    query_params = event["queryStringParameters"]
+    path_params = event["pathParameters"]
+    stage_vars = event["stageVariables"]
+
+    # TODO: remove this debug printing
+    print(f"Lambda authz headers: {headers}")
+    print(f"Lambda authz query_params: {query_params}")
+    print(f"Lambda authz path_params: {path_params}")
+    print(f"Lambda authz stage_vars: {stage_vars}")
+
+    # Parse the input for the parameter values
+
+    # TODO:
+    # - can do things like get the methodARN out of the event, use that to get
+    #   the identifier of the APIGW, account number, region, restapi id, stage,
+    #   method, etc as part of what to grant access to in the returned policy
+
+    # TODO: Check the values we determine we need against some TBD criteria and
+    #       return either an allow or deny policy. E.g. for this simple test,
+    #       probably want to check that a username (of the caller) provided
+    #       matches the name of the user we want to allow, and otherwise deny.
+    #       When denying, do so by raising `Exception("Unauthorized")` (which
+    #       gives a 401)
+
+    # TODO: right now, all shall pass. if this works, need to get front ends
+    #       passing in headers and such for this authorizer to use
+    return generate_policy("*", "Allow", "*")
+
+
+# Shamelessly taken from the example in teh AWS docs for Lambda Authorizers.
+# Changed to not be javascript style and to reduce redundancy...
+def generate_policy(principalId, effect, resource):
+    """"""
+    authz_resp = {}
+    authz_resp["principalId"] = principalId
+
+    if effect and resource:
+        policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": effect,
+                    "Resource": resource,
+                }
+            ],
+        }
+
+        authz_resp["policyDocument"] = policy_doc
+
+    # TODO: sample context, this is garbage data ATM
+    authz_resp["context"] = {
+        "some_ctx_str": "some_ctx_str_val",
+        "some_ctx_int": 42,
+        "some_ctx_bool": True,
+    }
+
+    return authz_resp

--- a/assets/api/authz/default_apigw_authorizer.py
+++ b/assets/api/authz/default_apigw_authorizer.py
@@ -20,10 +20,10 @@ def lambda_handler(event, context):
     #       caller) has the ability to set path params, headers and query
     #       params. all others are set by AWS
 
-    headers = event["headers"]
-    query_params = event["queryStringParameters"]
-    path_params = event["pathParameters"]
-    stage_vars = event["stageVariables"]
+    headers = event.get("headers", "NO HEADERS")
+    query_params = event.get("queryStringParameters", "NO QUERY STRING PARAMS")
+    path_params = event.get("pathParameters", "NO PATH PARAMS")
+    stage_vars = event.get("stageVariables", "NO STAGE VARIABLES")
 
     # TODO: remove this debug printing
     print(f"Lambda authz headers: {headers}")

--- a/assets/api/authz/default_apigw_authorizer.py
+++ b/assets/api/authz/default_apigw_authorizer.py
@@ -50,7 +50,7 @@ def lambda_handler(event, context):
     return generate_policy("*", "Allow", "*")
 
 
-# Shamelessly taken from the example in teh AWS docs for Lambda Authorizers.
+# Shamelessly taken from the example in the AWS docs for Lambda Authorizers.
 # Changed to not be javascript style and to reduce redundancy...
 def generate_policy(principalId, effect, resource):
     """"""

--- a/assets/api/data-analysis-pipeline/dap-openapi-301.yaml.j2
+++ b/assets/api/data-analysis-pipeline/dap-openapi-301.yaml.j2
@@ -5,24 +5,30 @@ info:
         "CAPE Data Analysis Pipeline API (***TODO: add more comment***)"
     version: "2024-11-04T20:50:49Z"
 servers:
-    # we do not provide x-amazon-apigateway-endpoint-configuration here (setting up the vpc endpoint)
-    # as we expect that to be set in the pulumi code setting up the RestApi. Don't want AWS ids in the
-    # repo
+{#
+    NOTE:
+        we do not provide x-amazon-apigateway-endpoint-configuration here (
+        setting up the vpc endpoint) as we expect that to be set in the pulumi 
+        code setting up the RestApi. Don't want AWS ids in the repo
+#}
     - url: "https://api.cape-dev.org/{basePath}"
       variables:
           basePath:
               # This value needs to map to the stage name exposed via the ALB
               default: "dap-dev"
 
-
-# TODO: May want to do override at the method level to allow fine grained 
-#       scoping and also allow override of authorizers for specific 
-#       endpoints...
+{#
+    TODO: May want to do override at the method level to allow fine grained 
+          scoping and also allow override of authorizers for specific 
+          endpoints...
+#}
 {% if authorizers %}
 security:
     {% for authorizer_name, _ in authorizers.items() %}
-    # NOTE: some authorizer types (e.g. oauth2) require scopes be defined which
-    #       would be done in place of the `[]` below
+{#    
+NOTE: some authorizer types (e.g. oauth2) require scopes be defined which
+      would be done in place of the `[]` below
+#}
     - {{ authorizer_name }}: []
     {% endfor %}
 {% endif %}
@@ -32,7 +38,9 @@ paths:
         get:
             responses:
                 "200":
-                    # TODO: need the response headers (i.e. cors)
+{#
+    TODO: need the response headers (i.e. cors)
+#}
                     description: "Success"
                     content:
                         application/json:
@@ -61,7 +69,7 @@ paths:
                 # this is the integration http method, not the endpoint http method. all lambda backed
                 # integrations are post
                 httpMethod: "POST"
-                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ list_daps_handler }}/invocations"
+                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ handlers['list_daps_handler'] }}/invocations"
                 passthroughBehavior: "when_no_match"
                 timeoutInMillis: 29000
                 type: "aws_proxy"
@@ -86,7 +94,9 @@ paths:
         get:
             responses:
                 "200":
-                    # TODO: need the response headers (i.e. cors)
+{#
+    TODO: need the response headers (i.e. cors)
+#}
                     description: "Success"
                     content:
                         application/json:
@@ -117,7 +127,7 @@ paths:
                         "Server error while getting list of available executors."
             x-amazon-apigateway-integration:
                 httpMethod: "POST"
-                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ list_dap_executors_handler }}/invocations"
+                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ handlers['list_dap_executors_handler'] }}/invocations"
                 passthroughBehavior: "when_no_match"
                 timeoutInMillis: 29000
                 type: "aws_proxy"
@@ -160,8 +170,10 @@ paths:
                                     description: >
                                         The S3 location to put pipeline output.
                                         Assumes permissions are set correctly.
-                                # TODO: ISSUE #TBD all below fields are specific to bactopia right now. also, the
-                                #       descriptions are bunk if we keep using these params
+{#
+    TODO: ISSUE #TBD all below fields are specific to bactopia right now. also, the
+          descriptions are bunk if we keep using these params
+#}
                                 r1Path:
                                     type: string
                                     description: The R1 path.
@@ -180,11 +192,13 @@ paths:
                                         Affects output directory and file names
             responses:
                 "200":
-                    # TODO: need the response headers (i.e. cors)
+{#
+    TODO: need the response headers (i.e. cors)
+#}
                     description: "Success submitting pipeline for execution."
             x-amazon-apigateway-integration:
                 httpMethod: "POST"
-                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ submit_dap_run_handler }}/invocations"
+                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ handlers['submit_dap_run_handler'] }}/invocations"
                 passthroughBehavior: "when_no_match"
                 timeoutInMillis: 29000
                 type: "aws_proxy"
@@ -227,29 +241,45 @@ components:
     securitySchemes:
         {% for authorizer_name, authorizer_def in authorizers.items() %}
         {{ authorizer_name }}:
-# TODO: this will only work for `request` type authorizers right now that have 
-#       identity sources as query string params and or header vals to check. 
-#       will need some work to support oauth2, oidc, single header, jwt, etc 
-#       setups
-            # TODO: this block (type/name/in) should not be changed for AWS
-            #       `request` lambda authorizers that use query params. when we
-            #       change to token or whatever this stuff will change
+{#
+    TODO: this will only work for `request` type authorizers right now that have 
+          identity sources as query string params and or header vals to check. 
+          will need some work to support oauth2, oidc, single header, jwt, etc 
+          setups
+#}
+{#
+    TODO: this block (type/name/in) should not be changed for AWS
+          `request` lambda authorizers that use query params. when we
+           change to token or whatever this stuff will change
+#}
             type: apiKey
             name: Unused
             in: header
-            # TODO: assumes custom (i.e. lambda) authtype currently
+{#
+    TODO: assumes custom (i.e. lambda) authtype currently
+#}
             x-amazon-apigateway-authtype: "custom"
             x-amazon-apigateway-authorizer: 
                 type : "{{ authorizer_def['type'] }}"
+                {# 
+                    identity source is not required, but specifying one will
+                    fail the API calls if that source is not present in the
+                    request. ao until we know what will always be there, we'll 
+                    allow an empty value here and will just not set an identity
+                    source unless told to.
+                #}
+                {% if authorizer_def["identity_sources"] %}
                 identitySource: "{{ authorizer_def['identity_sources'] }}"
+                {% endif %}
                 authorizerCredentials: "{{ authorizer_def['role'] }}"
                 authorizerUri: "{{ authorizer_def['uri'] }}"
                 authorizerResultTtlInSeconds: {{ authorizer_def['result_cached_sec'] }}
         {% endfor %}
     {% endif %}
 
-
-# NOTE:
-# we do not provide x-amazon-apigateway-policy here (setting up the policy for using the API)
-# as we expect that to be set in the pulumi code setting up the RestApi. Don't want AWS ids and
-# perms in the repo
+{#
+    NOTE:
+        we do not provide x-amazon-apigateway-policy here (setting up the 
+        policy for using the API) as we expect that to be set in the pulumi 
+        code setting up the RestApi. Don't want AWS ids and perms in the repo
+#}

--- a/assets/api/data-analysis-pipeline/dap-openapi-301.yaml.j2
+++ b/assets/api/data-analysis-pipeline/dap-openapi-301.yaml.j2
@@ -13,6 +13,20 @@ servers:
           basePath:
               # This value needs to map to the stage name exposed via the ALB
               default: "dap-dev"
+
+
+# TODO: May want to do override at the method level to allow fine grained 
+#       scoping and also allow override of authorizers for specific 
+#       endpoints...
+{% if authorizers %}
+security:
+    {% for authorizer_name, _ in authorizers.items() %}
+    # NOTE: some authorizer types (e.g. oauth2) require scopes be defined which
+    #       would be done in place of the `[]` below
+    - {{ authorizer_name }}: []
+    {% endfor %}
+{% endif %}
+    
 paths:
     /analysispipelines:
         get:
@@ -207,6 +221,35 @@ components:
                     schema:
                         type: "string"
             content: {}
+
+    # if we have one or more authorizers defined, we need to render them here
+    {% if authorizers %}
+    securitySchemes:
+        {% for authorizer_name, authorizer_def in authorizers.items() %}
+        {{ authorizer_name }}:
+# TODO: this will only work for `request` type authorizers right now that have 
+#       identity sources as query string params and or header vals to check. 
+#       will need some work to support oauth2, oidc, single header, jwt, etc 
+#       setups
+            # TODO: this block (type/name/in) should not be changed for AWS
+            #       `request` lambda authorizers that use query params. when we
+            #       change to token or whatever this stuff will change
+            type: apiKey
+            name: Unused
+            in: header
+            # TODO: assumes custom (i.e. lambda) authtype currently
+            x-amazon-apigateway-authtype: "custom"
+            x-amazon-apigateway-authorizer: 
+                type : "{{ authorizer_def['type'] }}"
+                identitySource: "{{ authorizer_def['identity_sources'] }}"
+                authorizerCredentials: "{{ authorizer_def['role'] }}"
+                authorizerUri: "{{ authorizer_def['uri'] }}"
+                authorizerResultTtlInSeconds: {{ authorizer_def['result_cached_sec'] }}
+        {% endfor %}
+    {% endif %}
+
+
+# NOTE:
 # we do not provide x-amazon-apigateway-policy here (setting up the policy for using the API)
 # as we expect that to be set in the pulumi code setting up the RestApi. Don't want AWS ids and
 # perms in the repo

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -553,13 +553,6 @@ def get_api_lambda_authorizer_policy(funct_arns: list[Output] | None = None):
             ],
             "Resource": "arn:aws:logs:*:*:*",
         },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "sts:AssumeRole",
-            ],
-            "Resource": "*",
-        },
     ]
 
     # TODO: figure out what the authorizer actually needs grants on

--- a/capeinfra/iam.py
+++ b/capeinfra/iam.py
@@ -519,6 +519,48 @@ def get_api_policy(grants: dict[str, list[Output]]):
     )
 
 
+# TODO: grants doesn't do anything here yet. Not sure what we'll add access to
+#       at this point
+def get_api_authorizer_policy(grants: dict[str, list[Output]]):
+    """Get a role policy statement for the an API Lamda Authorizer.
+
+    The authorizer for an API will be given access as configured in
+    `grants`. Lambda logging will be unconditionally enabled without
+    configuration.
+
+    At present, `grants` is a placeholder and cannot be used to modify the
+    policy. This will change as the needs of the authorizers matures.
+
+
+    Args:
+        grants: A dict of the format:
+            {***TBD***}
+
+    Returns:
+        The policy statement as a dictionary json encoded string.
+    """
+    stmnts = [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+            ],
+            "Resource": "arn:aws:logs:*:*:*",
+        },
+    ]
+
+    # TODO: figure out what the authorizer actually needs grants on
+
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": stmnts,
+        },
+    )
+
+
 def get_sqs_lambda_glue_trigger_policy(queue_name: str, job_names: list) -> str:
     """Get a role policy statement for reading from sqs and starting glue jobs.
 

--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -398,14 +398,6 @@ class CapeRestApi(CapeComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        self.restapi.execution_arn.apply(
-            lambda a: print(f"REST API EXECUTION ARN: {a}")
-        )
-
-        self.api_authorizer.arn.apply(
-            lambda a: print(f"API AUTHORIZER ARN: {a}")
-        )
-
         # now give the API gateway the permission to invoke the authorizer
         # lambda
         Output.all(

--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -220,9 +220,13 @@ class CapeRestApi(CapeComponentResource):
         )
 
         for authz_name, authz_def in self._authorizers.items():
+            print(f"Authz_def: {authz_def}")
+
             spec_kwargs["authorizers"][authz_name] = {
                 "type": authz_def["type"],
-                "identity_sources": ",".join(authz_def["identity_sources"]),
+                "identity_sources": ",".join(
+                    authz_def["identity_sources"] or []
+                ),
                 "result_cached_sec": authz_def["result_cached_sec"],
                 "role": authz_def["role"].arn,
                 "uri": authz_def["handler"].invoke_arn,

--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -363,17 +363,6 @@ class CapeRestApi(CapeComponentResource):
                 "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
             )
 
-            # log group and log stream for the authorizer
-            # authorizer_logging_config = None
-            #
-            # if authorizer_def.get("logging_enabled", False):
-            #     authorizer_logging_config = {
-            #         "log_format": "Text",
-            #         "log_group": self._authorizer_log_group.name.apply(
-            #             lambda a: f"{a}"
-            #         ),
-            #     }
-
             # Create our Lambda function for the authorizer
             # TODO: In the case that 2 apis use the same authorizer function
             #       code, this will create a new function with the same code if

--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -343,7 +343,7 @@ class CapeRestApi(CapeComponentResource):
         # now give the API gateway the permission to invoke the authorizer
         # lambda
         aws.lambda_.Permission(
-            f"{self.name}-api-authz-allowlmbd",
+            f"{self.name}-authz-allowlmbd",
             action="lambda:InvokeFunction",
             function=self.api_authorizer_handler.arn,
             principal="apigateway.amazonaws.com",

--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -220,7 +220,6 @@ class CapeRestApi(CapeComponentResource):
         )
 
         for authz_name, authz_def in self._authorizers.items():
-            print(f"Authz_def: {authz_def}")
 
             spec_kwargs["authorizers"][authz_name] = {
                 "type": authz_def["type"],

--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -325,7 +325,7 @@ class CapeRestApi(CapeComponentResource):
             authz_name = (
                 f"{self.api_name}-api-default-authorizer"
                 if authorizer_name == "default"
-                else f"{authorizer-name}-authorizer"
+                else f"{authorizer_name}-authorizer"
             )
 
             self._authorizers[authz_name].update(authorizer_def)
@@ -364,15 +364,15 @@ class CapeRestApi(CapeComponentResource):
             )
 
             # log group and log stream for the authorizer
-            authorizer_logging_config = None
-
-            if authorizer_def.get("logging_enabled", False):
-                authorizer_logging_config = {
-                    "log_format": "Text",
-                    "log_group": self._authorizer_log_group.name.apply(
-                        lambda a: f"{a}"
-                    ),
-                }
+            # authorizer_logging_config = None
+            #
+            # if authorizer_def.get("logging_enabled", False):
+            #     authorizer_logging_config = {
+            #         "log_format": "Text",
+            #         "log_group": self._authorizer_log_group.name.apply(
+            #             lambda a: f"{a}"
+            #         ),
+            #     }
 
             # Create our Lambda function for the authorizer
             # TODO: In the case that 2 apis use the same authorizer function
@@ -386,7 +386,17 @@ class CapeRestApi(CapeComponentResource):
                 ),
                 # TODO: this runtime should maybe be configurable long term
                 runtime="python3.10",
-                logging_config=authorizer_logging_config,
+                # logging_config=authorizer_logging_config,
+                logging_config=(
+                    {
+                        "log_format": "Text",
+                        "log_group": self._authorizer_log_group.name.apply(
+                            lambda a: f"{a}"
+                        ),
+                    }
+                    if authorizer_def.get("logging_enabled", False)
+                    else None
+                ),
                 # in this case, the zip file for the lambda deployment is
                 # being created by this code. and the zip file will be
                 # called index. so the handler must be start with `index`

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -188,7 +188,6 @@ class PrivateSwimlane(ScopedSwimlane):
             resource_grants,
             self.api_vpcendpoint,
             self.apigw_domainname.domain_name,
-            self.apis[api_name]["spec"]["authorizer"] or None,
             config=self.apis[api_name]["spec"],
             desc_name=f"{self.apis[api_name]['spec']['desc']}",
             opts=ResourceOptions(parent=self),

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -188,6 +188,7 @@ class PrivateSwimlane(ScopedSwimlane):
             resource_grants,
             self.api_vpcendpoint,
             self.apigw_domainname.domain_name,
+            self.apis[api_name]["spec"]["authorizer"] or None,
             config=self.apis[api_name]["spec"],
             desc_name=f"{self.apis[api_name]['spec']['desc']}",
             opts=ResourceOptions(parent=self),


### PR DESCRIPTION
# TO TEST
* this has been deployed, but can be redone if desired by removing the current DAP rest api (remove the base path mapping of the restapi first, it's under custom domains in api gateway), doing a `pulumi refresh` and then deploying.
* easiest way to see this doing a thing is:
  * get on the cape vpn
  * open the cloudwatch logs for the authz lambda function
  * `curl -v -k https://api.cape-dev.org/dap-dev/analysispipelines` to hit an api endpoint gated by the authorizer
  * look at most recent claoudwatch stream for the authorizer and see that a new entry comes in that prints a bunch of environment info for the authorizer (parameters and such)