### PR TITLE
221 consider move to opa policy engine

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -103,11 +103,11 @@ config:
         # NOTE: This currently only supports github repositories
         #
         # Contains information required to pull a versioned release of a
-        # Policy As Code repo. This repostory's schema and policies will be
+        # Policy As Code repo. This repository's schema and policies will be
         # used to populate a policy engine (store, schema and policies). 
         # Currently, this repo must provide a shcema and policies in the Cedar 
         # json format. This mapping has the following keys:
-        # * `repo_url: the url to the (publically accessible) hosted
+        # * `repo_url: the url to the (publicly accessible) hosted
         #   repository. This should not end in `.git`
         # * `version`: This is the version of the artifact to get. This
         #   version will most likely match a repo tag

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -114,10 +114,6 @@ config:
         # * `artifact_name`: The name of the release artifact to get. A
         #   release could contain multiple items for which only a subset is
         #   needed.
-        authz_policy_engine:
-            repo_url: "https://github.com/cape-ph/cape-cedar-pac"
-            version: "2025.04.29"
-            artifact_name: "cape-cedar-pac.zip"
 
         # `glue` (mapping, optional)
         # Contains meta configuration related to aws glue.
@@ -227,6 +223,8 @@ config:
             #     time, but the name is reserved for the future
             #   * `app`: there is no special handling for this type at this
             #     time, but the name is reserved for the future
+            #   * `service`: there is no special handling for this type at this
+            #     time, but the name is reserved for the future
             #   * `vpn`: any subnet marks as the VPN type will be configured to
             #     be a target of the external client VPN setup.
             # * `public`: (boolean, optional)
@@ -272,6 +270,12 @@ config:
                   type: vpn
                   routes:
                       - "nataz1"
+                - name: srvcaz1
+                  cidr-block: 10.0.124.0/23
+                  <<: *az1
+                  type: service
+                  routes:
+                      - "nataz1"
                 # AZ 2
                 - name: nataz2
                   cidr-block: 10.0.255.0/24
@@ -296,6 +300,12 @@ config:
                   type: vpn
                   routes:
                       - "nataz2"
+                - name: srvcaz2
+                  cidr-block: 10.0.252.0/23
+                  <<: *az2
+                  type: service
+                  routes:
+                      - "nataz1"
             # `api` (mapping, optional)
             # Contains the configuration for apis and the API application load
             # balancer. If this is not included, a default configuration will be
@@ -617,6 +627,55 @@ config:
                           rebuild_on_change: True
                       services:
                           - athena
+                    - name: "opa"
+                      image: "ami-05080e4998b881ee0"
+                      public_ip: False
+                      instance_type: "t3a.medium"
+                      subnet_types:
+                          - service
+                      subdomain: "opa"
+                      # TODO: don't think we need a cognito client setup here
+                      #       (no SSO needs on this instance) at this time.
+                      #       could change if we need to setup userpool queries
+                      #       in opa directly i guess...
+                      port: 8181
+                      protocol: "HTTP"
+                      healthcheck:
+                          path: "/"
+                          port: 8181
+                          protocol: "HTTP"
+                          matcher: "302"
+                      user_data:
+                          template: assets/instance/user-data/templates/opa.j2
+                          # TODO: define template vars
+                          rebuild_on_change: True
+                          # NOTE: At this time, the opa instance only needs to 
+                          #       read from s3 to get policy bundles. This will
+                          #       probably change in the future (remain an
+                          #       option, but not be the only or preferred
+                          #       mechanism.
+                          vars:
+                              # TODO: think we're going to want this pulling
+                              #       from GH repo releases in addition to off
+                              #       the s3 bucket. we could also have part of
+                              #       the deploy pull from repos and then place
+                              #       them in s3. see if opa supports pull right
+                              #       from GH though
+                              bundle_path: "bundles/opa-bundle-cape.tar.gz"
+                              # TODO: these values are for dev and are way too
+                              # fast for prod
+                              meta_bundle_min_dl_delay: 10
+                              meta_bundle_max_dl_delay: 20
+
+
+                      services:
+                          # TODO: Issue #186 - It would be awesome if we could
+                          #       specify needed actions (e.g. R/W/X type 
+                          #       stuff) here as well as give some indication of
+                          #       *which* service endpoint we care about (e.g.
+                          #       here we would care about specifying which
+                          #       bucket we want to read from
+                          - s3
             # `vpn` (mapping, required)
             # Contains configuration for the vpn for the swimlane.
             # NOTE: At this time, we roll the VPN in with each swimlane. This

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -655,17 +655,11 @@ config:
                           #       option, but not be the only or preferred
                           #       mechanism.
                           vars:
-                              # TODO: think we're going to want this pulling
-                              #       from GH repo releases in addition to off
-                              #       the s3 bucket. we could also have part of
-                              #       the deploy pull from repos and then place
-                              #       them in s3. see if opa supports pull right
-                              #       from GH though
-                              bundle_path: "bundles/opa-bundle-cape.tar.gz"
-                              # TODO: these values are for dev and are way too
-                              # fast for prod
-                              meta_bundle_min_dl_delay: 10
-                              meta_bundle_max_dl_delay: 20
+                              bundle_repo_name: "https://github.com/cape-ph/cape-opa-policy"
+                              bundle_version: "2025.05.14"
+                              bundle_asset_name: "cape-opa-bundle.tar.gz"
+                              meta_bundle_min_dl_delay: 120
+                              meta_bundle_max_dl_delay: 300
 
 
                       services:

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -98,6 +98,27 @@ config:
             # mechanism discussed in the readme.
             # users_extra: "./assets-untracked/principals/users.csv"
 
+        # `authz_policy_engine` (mapping, required)
+        #
+        # NOTE: This currently only supports github repositories
+        #
+        # Contains information required to pull a versioned release of a
+        # Policy As Code repo. This repostory's schema and policies will be
+        # used to populate a policy engine (store, schema and policies). 
+        # Currently, this repo must provide a shcema and policies in the Cedar 
+        # json format. This mapping has the following keys:
+        # * `repo_url: the url to the (publically accessible) hosted
+        #   repository. This should not end in `.git`
+        # * `version`: This is the version of the artifact to get. This
+        #   version will most likely match a repo tag
+        # * `artifact_name`: The name of the release artifact to get. A
+        #   release could contain multiple items for which only a subset is
+        #   needed.
+        authz_policy_engine:
+            repo_url: "https://github.com/cape-ph/cape-cedar-pac"
+            version: "2025.04.29"
+            artifact_name: "cape-cedar-pac.zip"
+
         # `glue` (mapping, optional)
         # Contains meta configuration related to aws glue.
         glue:

--- a/assets/instance/user-data/templates/opa.j2
+++ b/assets/instance/user-data/templates/opa.j2
@@ -2,14 +2,43 @@
 
 sudo tee /etc/opa/config/opa-config.yaml <<EOF
 
-# TEE'd off config...
+services:
+  cape-meta-bundles:
+    url: https://{{ bucket_name }}
+    credentials:
+      s3_signing:
+        metadata_credentials:
+          service: s3
+          aws_region: {{ aws_region }}
+          iam_role: {{ ec2_role }}
+bundles:
+  authz:
+    service: cape-meta-bundles
+    resource: {{ bundle_path }}
+    polling:
+      # NOTE: these are set with defaults for polling the bundles in case 
+      #       values are not provided. for debug, set these values low (e.g. 
+      #       < 30 sec), for prod, the correct value is really a function of 
+      #       how often bundles change and how long a delay in new bundles 
+      #       being applied is ok.
+      min_delay_seconds: {{ meta_bundle_min_dl_delay | default(60) }}
+      max_delay_seconds: {{ meta_bundle_max_dl_delay | default(300) }}
 
 labels:
   app: cape-opa-default-config
-  region: east
+  region: {{ aws_region }}
   environment: dev
 
+decision_logs:
+  service: cape-meta-bundles
+  resource: /logs
+  console: true
+
+status:
+  service: cape-meta-bundles
+
 default_decision: deny
+
 EOF
 
 sudo systemctl restart opa.service

--- a/assets/instance/user-data/templates/opa.j2
+++ b/assets/instance/user-data/templates/opa.j2
@@ -3,18 +3,29 @@
 sudo tee /etc/opa/config/opa-config.yaml <<EOF
 
 services:
-  cape-meta-bundles:
-    url: https://{{ bucket_name }}
-    credentials:
-      s3_signing:
-        metadata_credentials:
-          service: s3
-          aws_region: {{ aws_region }}
-          iam_role: {{ ec2_role }}
+  cape-default-github-bundle:
+    url: {{ bundle_repo_name }}/releases/download
+
+# NOTE: for now we're handling pulling versioned releases of policy bundles
+#       from github repositories. If the bundles get big (e.g. there's a bunch
+#       of data files embedded) or some other operationl reason we wish to
+#       consider holding cached versions of the bundles somewhere closer to
+#       load from, we could put them on s3 at some periodicity and use a block
+#       like the following to set that up as a bundle service
+#
+# cape-s3-bundles
+#   url: https://<bucket_name>.s3.amazonaws.com
+#   credentials:
+#     s3_signing:
+#       metadata_credentials:
+#          service: s3
+#          aws_region: <aws_region>
+#          iam_role: <ec2 role name>
+
 bundles:
   authz:
-    service: cape-meta-bundles
-    resource: {{ bundle_path }}
+    service: cape-default-github-bundle
+    resource: {{ bundle_version }}/{{ bundle_asset_name }}
     polling:
       # NOTE: these are set with defaults for polling the bundles in case 
       #       values are not provided. for debug, set these values low (e.g. 
@@ -30,12 +41,12 @@ labels:
   environment: dev
 
 decision_logs:
-  service: cape-meta-bundles
+  service: cape-default-github-bundle
   resource: /logs
   console: true
 
 status:
-  service: cape-meta-bundles
+  service: cape-default-github-bundle
 
 default_decision: deny
 

--- a/assets/instance/user-data/templates/opa.j2
+++ b/assets/instance/user-data/templates/opa.j2
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+sudo tee /etc/opa/config/opa-config.yaml <<EOF
+
+# TEE'd off config...
+
+labels:
+  app: cape-opa-default-config
+  region: east
+  environment: dev
+
+default_decision: deny
+EOF
+
+sudo systemctl restart opa.service

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -268,7 +268,6 @@ class EtlJob(CapeComponentResource):
                     args["assets_bucket"],
                 )
             ),
-            srvc_policy_attach=None,
             opts=ResourceOptions(parent=self),
         )
 

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -35,12 +35,15 @@ class SubnetType(str, Enum):
                      but the name is reserved for the future
         * `app`: there is no special handling for this type at this time, but
                  the name is reserved for the future
+        * `service`: there is no special handling for this type at this time,
+                     but the name is reserved for the future
     """
 
     NAT = "nat"
     VPN = "vpn"
     COMPUTE = "compute"
     APP = "app"
+    SERVICE = "service"
 
 
 class ScopedSwimlane(CapeComponentResource):

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -720,7 +720,7 @@ class PrivateSwimlane(ScopedSwimlane):
                 rebuild_on_ud_change = ud_info["rebuild_on_change"]
                 template = get_j2_template_from_path(ud_info["template"])
 
-                template_args: dict[str, Output|str] = {}
+                template_args: dict[str, Output | str] = {}
                 template_args["domain"] = domain
                 # if there is a cognito client, pass in the necessary client
                 # information

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -727,8 +727,7 @@ class PrivateSwimlane(ScopedSwimlane):
                             lambda d:f"https://{d}.auth.{self.aws_region}.amazoncognito.com"
                         )
                     )
-                template_args["vars"] = ud_info["vars"]
-
+                template_args["vars"] = ud_info.get("vars", {})
                 user_data = Output.all(**template_args).apply(
                     lambda args: template.render(**args["vars"], **args)
                 )

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -736,18 +736,12 @@ class PrivateSwimlane(ScopedSwimlane):
                         )
                     )
 
-                # TODO: we are passing in the aws region, ec2 role (of the
-                #       instance profile) and the meta assets bucket name to all
-                #       instance templates. Not really a big deal i don't think,
+                # TODO: we are passing in the aws region to all instance
+                #       templates. Not really a big deal i don't think,
                 #       but it does pollute the namespace a bit. perhaps
-                #       consider a context object based on instance type? (where
-                #       the ec2 instances would get a context with
-                #       region/role/bucket name)?
+                #       consider a Context object based on instance type or
+                #       something like that?
                 template_args["aws_region"] = self.aws_region
-                template_args["ec2_role"] = instance_profile.role
-                template_args["bucket_name"] = (
-                    capeinfra.meta.automation_assets_bucket.bucket.bucket_domain_name
-                )
 
                 template_args["vars"] = ud_info.get("vars", {})
                 user_data = Output.all(**template_args).apply(

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -720,7 +720,7 @@ class PrivateSwimlane(ScopedSwimlane):
                 rebuild_on_ud_change = ud_info["rebuild_on_change"]
                 template = get_j2_template_from_path(ud_info["template"])
 
-                template_args: dict[str, Output] = {}
+                template_args: dict[str, Output|str] = {}
                 template_args["domain"] = domain
                 # if there is a cognito client, pass in the necessary client
                 # information

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -794,9 +794,7 @@ class PrivateSwimlane(ScopedSwimlane):
                         "hc_args": aicfg.get("healthcheck", None),
                     }
 
-    def _create_instance_profile(
-        self, ia_name: str, services: list[str] | None = None
-    ):
+    def _create_instance_profile(self, ia_name: str, services: list[str] = []):
         """Return an instance profile with grants needed for provided services.
 
         Args:
@@ -853,9 +851,14 @@ class PrivateSwimlane(ScopedSwimlane):
                 "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
             )
 
+        # for shortening line and making linter happy
+        desc_services = (
+            ":".join(services) if services else "<NO SERVICES CONFIGURED>"
+        )
+
         ec2_role = get_inline_role(
             f"{self.basename}-ec2role-{disemvowel(ia_name)}",
-            f"{self.desc_name} EC2 instance role for {':'.join(services)} access",
+            f"{self.desc_name} EC2 instance role for {desc_services} access",
             "ec2",
             "ec2.amazonaws.com",
             json.dumps(

--- a/capeinfra/util/file.py
+++ b/capeinfra/util/file.py
@@ -1,5 +1,7 @@
 """File-related utiliy functions."""
 
+import zipfile
+
 
 def file_as_string(pth: str) -> str:
     """Returns the contents of a file in a string.
@@ -16,3 +18,16 @@ def file_as_string(pth: str) -> str:
         s = f.read()
 
     return s
+
+
+def unzip_to(zip_path: str, target_dir: str = "/tmp"):
+    """Unzip a zip file to the specified directory.
+
+    Args:
+        zip_path: The path to the zip file.
+        target_dir: The directory to unzip to. If not specified, the file will
+                    be unzipped to `/tmp` to a directory with the same name as
+                    the zipf file.
+    """
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(target_dir)

--- a/capeinfra/util/repo.py
+++ b/capeinfra/util/repo.py
@@ -1,0 +1,33 @@
+"""Module relating to repository actions (e.g. downloading a github release)"""
+
+import urllib.request
+
+
+def get_github_release_artifact(
+    repo_url: str,
+    artifact_name: str,
+    version: str = "latest",
+    dl_loc: str = "/tmp",
+) -> str | None:
+    """Download the given release artifact and return the local path or None.
+
+    NOTE: Currently the only error checking done on the downloaded file is to
+    check for non-0 filesize. In that case None will be returned.
+
+    Args:
+        repo_url: The github repository URL (should not include `.git`)
+        artifact_name: The name of the release artifact to get.
+        version: The version of the release artifact to get. Defaults to
+                 `latest`, which may not be valid for the given repo.
+        dl_loc: A local download location for the artifact. Defaults to `/tmp`.
+    """
+
+    artifact_url = "/".join(
+        [repo_url, "releases", "download", version, artifact_name]
+    )
+
+    dl_pth = "/".join([dl_loc, artifact_name])
+    local_pth, http_msg = urllib.request.urlretrieve(artifact_url, dl_pth)
+
+    # TODO: better verification than checking for non-0 file size.
+    return local_pth if int(http_msg.get("Content-Length")) else None

--- a/capeinfra/util/repo.py
+++ b/capeinfra/util/repo.py
@@ -29,5 +29,7 @@ def get_github_release_artifact(
     dl_pth = "/".join([dl_loc, artifact_name])
     local_pth, http_msg = urllib.request.urlretrieve(artifact_url, dl_pth)
 
+    # check the content length header to see if the get worked or not. if we
+    # don't get a content length back then this will end up None as well.
     # TODO: better verification than checking for non-0 file size.
-    return local_pth if int(http_msg.get("Content-Length")) else None
+    return local_pth if int(http_msg.get("Content-Length", 0)) else None


### PR DESCRIPTION
This has been deployed. At time of writing tthe PR, the OPA ec2 instances are at `10.0.125.26` and `10.0.252.25`.

# TO TEST
* get on aws vpn
* ssh into one of the machines (or both if you're thorough) and ensure:
  * the `opa` service is running normally and reports no errors (except warnings about http 405's when polling for updates)
  * The file `/etc/opa/config/opa-config.yaml` looks reasonable
  * The file `/etc/opa/systemd/opa.service` looks reasonable
* From outside the EC2 instances (e.g. from the CLI of your laptop) execute the following and make sure the output matches (the decision id *could be different, but the allow should remain true)
```sh
15:27 $ curl -X POST 10.0.125.26:8181/v1/data/cape/capeallow -H "Content-Type: application/json" --data-binary '{"input": {}}'
{"decision_id":"10c4a802-d4ec-48df-9452-35ec81c05e03","result":{"allow":true}}
```