### PR TITLE
241 s3 api gets

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -523,6 +523,17 @@ config:
                                     "getuserattributeval Lambda Function"
                                 memory_size: 128
                                 timeout: 10
+                          - id: "get_s3_contents_handler"
+                            name: "gets3contents"
+                            code: "assets/api/capi/handlers/get_s3_contents.py"
+                            funct_args:
+                                handler: "index.index_handler"
+                                runtime: "python3.10"
+                                architectures:
+                                    - "x86_64"
+                                description: "gets3contents Lambda Function"
+                                memory_size: 128
+                                timeout: 10
                     # TODO: ISSUE 231 - remove this api when it's in the main
                     #                   capi api
                     - name: dap

--- a/assets/api/capi/capi-openapi-301.yaml.j2
+++ b/assets/api/capi/capi-openapi-301.yaml.j2
@@ -300,6 +300,83 @@ paths:
               passthroughBehavior: "when_no_match"
               timeoutInMillis: 29000
               type: "mock"
+    /objstorage/contents:
+        get:
+            parameters:
+                - in: query
+                  name: bucket
+                  schema:
+                    type: string
+                    description: "The name of the bucket to get contents of"
+                  required: true
+                - in: query
+                  name: prefix
+                  schema:
+                    type: string
+                    description: "The optional object key prefix to limit
+                    results to" 
+                  required: false
+            responses:
+                "200":
+                    description: "Success"
+                    content:
+                        application/json:
+                            schema:
+
+                                type: array
+                                description:
+                                    "An array of objects containing information
+                                    about objects in the desired object storage
+                                    location."
+                                items:
+                                    type: object
+
+                                    {# TODO: don't know yet
+                                    properties:
+                                        objstore_name:
+                                            type: string
+                                            description: An object store name
+                                        prefixes:
+                                            type: array
+                                            description:
+                                                Array of names of prefixes in
+                                                the object store
+                                            items:
+                                               type: string
+                                               description: 
+                                                    A name of a prefix the user can write
+                                                    to for the outer-scoped
+                                                    object store.
+                                    #}
+                {# TODO: default response (for 4xx) #}
+                "500":
+                    description:
+                        "Server Error - Unable to query object storage API (error occurred)."
+            x-amazon-apigateway-integration:
+                # this is the integration http method, not the endpoint http method. all lambda backed
+                # integrations are post
+                httpMethod: "POST"
+                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ handlers['get_s3_contents_handler'] }}/invocations"
+                passthroughBehavior: "when_no_match"
+                timeoutInMillis: 29000
+                type: "aws_proxy"
+        options:
+            responses:
+                "200":
+                    $ref: "#/components/responses/200OptionsCors"
+            x-amazon-apigateway-integration:
+              responses:
+                default:
+                    statusCode: "200"
+                    responseParameters:
+                        method.response.header.Access-Control-Allow-Methods: "'OPTIONS,POST'"
+                        method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+                        method.response.header.Access-Control-Allow-Origin: "'*'"
+              requestTemplates:
+                  application/json: "{'statusCode':200}"
+              passthroughBehavior: "when_no_match"
+              timeoutInMillis: 29000
+              type: "mock"
 # resusable components that follow OpenApi 3.0.1 spec
 components:
     responses:

--- a/assets/api/capi/handlers/get_s3_contents.py
+++ b/assets/api/capi/handlers/get_s3_contents.py
@@ -1,0 +1,119 @@
+"""Lambda for handling GETs for S3 contents the authn'd user has access to."""
+
+import json
+
+import boto3
+from botocore.exceptions import ClientError
+from capepy.aws.utils import decode_error
+
+
+def bad_param_response():
+    """Gets a response data object and status code when bad params are given.
+
+    :return: A tuple containins a response data object and an HTTP 400 status
+             code.
+    """
+    return (
+        {"message": ("Missing required query string parameters: bucket")},
+        400,
+    )
+
+
+def index_handler(event, context):
+    """Handler for the GET for S3 locations the authn'd user has access to.
+
+    If there is no `Authorization` header present, this will return a 401.
+
+    :param event: The event object that contains the HTTP request.
+    :param context: Context object.
+    """
+
+    # Create an S3 client object
+    s3_client = boto3.client("s3")
+
+    try:
+
+        headers = event.get("headers", {})
+
+        ### LEFTOFF
+        # TODO:
+        # - pull out bucket name and (optional) prefix. handler errors
+        # - query for contents of said bucket/prefix with boto3
+        # - add todos for authz/opa
+        # - ensure list bucket contents perms are on the api
+
+        qsp = event.get("queryStringParameters")
+
+        if qsp is None:
+            resp_data, resp_status = bad_param_response()
+        else:
+            bucket = qsp.get("bucket")
+            prefix = qsp.get("prefix")
+
+            # TODO: in the future bucket should be set as a required param. prefix
+            #       will not be not required
+            if not bucket:
+                resp_data, resp_status = bad_param_response()
+            else:
+                buckobj_paginator = s3_client.get_paginator("list_objects_v2")
+
+                # NOTE: if you pass `Delimiter` here all you get back is
+                #       prefixes names (and not the contents of those prefixes
+                page_iter = buckobj_paginator.paginate(
+                    Bucket=bucket, Prefix=prefix or ""
+                )
+
+                bucket_objects = []
+
+                for page in page_iter:
+                    if "Contents" not in page:
+                        # this will happen if there are no objects (at all or in
+                        # a specified prefix). also catches if a bad prefix is
+                        # given
+                        continue
+
+                    for bobj in page["Contents"]:
+                        # TODO: we'll eventually want more than the object name
+                        #       here probs. otherwise this would just be a list
+                        #       comp
+                        bucket_objects.append(bobj["Key"])
+
+                resp_status = 200
+                resp_data = {
+                    "bucket": bucket,
+                    "objects": bucket_objects,
+                }
+
+        # And return our response
+        return {
+            "statusCode": resp_status,
+            "headers": {
+                "Content-Type": "application/json",
+                # TODO: ISSUE #141 CORS bypass. We do not want this long term.
+                #       When we get all the api and web resources on the same
+                #       domain, this may not matter too much. But we may
+                #       eventually end up with needing to handle requests from
+                #       one domain served up by another domain in a lambda
+                #       handler. In that case we'd need to be able to handle
+                #       CORS, and would want to look into allowing
+                #       configuration of the lambda (via pulumi config that
+                #       turns into env vars for the lambda) that set the
+                #       origins allowed for CORS.
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "OPTIONS,GET",
+            },
+            "body": json.dumps(resp_data),
+        }
+    except ClientError as err:
+        code, message = decode_error(err)
+
+        msg = (
+            f"Error during fetch of object storage locations for user. {code} "
+            f"{message}"
+        )
+
+        return {
+            "statusCode": 500,
+            "body": msg,
+        }


### PR DESCRIPTION
# TO TEST
This has been deployed and is testable with curl (while on the cape vpn):

## Test endpoint with no params (should get 400 and error message due to missing bucket)
```bash
curl -k "https://api.cape-dev.org/capi-dev/objstorage/contents" | jq
```

## Test endpoint with bucket only (should get 200 and all bucket contents)
```bash
curl -k "https://api.cape-dev.org/capi-dev/objstorage/contents?bucket=ccd-dlh-t-hai-input-raw-vbkt-s3-9e72cfa" | jq
```

## Test endpoint with bucket and prefix (should get 200 and and all objects with prefix)
```bash
curl -k "https://api.cape-dev.org/capi-dev/objstorage/contents?bucket=ccd-dlh-t-hai-input-raw-vbkt-s3-9e72cfa&prefix=tnl" | jq
```

## Test endpoint with bucket and bad prefix (should get 200 and no objects)
```bash
curl -k "https://api.cape-dev.org/capi-dev/objstorage/contents?bucket=ccd-dlh-t-hai-input-raw-vbkt-s3-9e72cfa&prefix=dne" | jq
```