### PR TITLE
feat(private): allow group and user extra files to be missing

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -66,7 +66,7 @@ config:
             # create. May be a full path or relative to repo root. This file can
             # be keps out of the repo using something like the assets-untracked
             # mechanism discussed in the readme.
-            # groups_extra: "./assets-untracked/principals/groups.csv"
+            groups_extra: "./assets-untracked/principals/groups.csv"
 
             # `users`  (mapping[], required)
             # Contains user specifications that are required for all cape
@@ -84,7 +84,7 @@ config:
                   temporary_password: 1CapeCodUser!
                   groups:
                       - Admins
-                  attrs_file: assets-untracked/principals/attrs/cape.admin.attrs.json
+                  attrs_file: ./assets-untracked/principals/attrs/cape.admin.attrs.json
                 # TODO: this user probably shouldn't actually be in here long
                 #       term. This is the kind of user that the `users_extra`
                 #       file is intended for. THIS IS JUST FOR TESTING IDENTITY
@@ -99,7 +99,7 @@ config:
             # create. May be a full path or relative to repo root. This file can
             # be keps out of the repo using something like the assets-untracked
             # mechanism discussed in the readme.
-            # users_extra: "assets-untracked/principals/users.csv"
+            users_extra: "./assets-untracked/principals/users.csv"
 
         # `authz_policy_engine` (mapping, required)
         #

--- a/capeinfra/meta/capemeta.py
+++ b/capeinfra/meta/capemeta.py
@@ -2,11 +2,12 @@
 
 import csv
 import json
+import os
 from typing import Any
 
 import pulumi_aws as aws
 from boto3.dynamodb.types import TypeSerializer
-from pulumi import FileArchive, FileAsset, Output, ResourceOptions
+from pulumi import FileArchive, FileAsset, Output, ResourceOptions, log
 
 import capeinfra
 from capeinfra.iam import get_inline_role
@@ -544,6 +545,10 @@ class CapePrincipals(CapeComponentResource):
         # Doing basic column checking to make sure the file is well formed.
         expected_cols = ["name", "description", "precedence"]
 
+        if not os.path.exists(filepth):
+            log.warn(f"Unable to locate specified groups file: {filepth}", self)
+            return
+
         with open(filepth) as grpcsv:
             grpreader = csv.reader(grpcsv, skipinitialspace=True)
             # our first row will be column names. grab em and make sure we have
@@ -579,6 +584,10 @@ class CapePrincipals(CapeComponentResource):
         """
         # Doing basic column checking to make sure the file is well formed.
         expected_cols = ["email", "temporary_password", "groups", "attrs_file"]
+
+        if not os.path.exists(filepth):
+            log.warn(f"Unable to locate specified user file: {filepth}", self)
+            return
 
         with open(filepth) as usrcsv:
             usrreader = csv.reader(usrcsv, skipinitialspace=True)

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any
 
 import pulumi_aws as aws
-from pulumi import ResourceOptions, warn
+from pulumi import ResourceOptions, log
 
 # TODO: ISSUE #145 this import is only needed for the temporary DAP S3 handling.
 #       it should not be here after 145.
@@ -333,10 +333,11 @@ class ScopedSwimlane(CapeComponentResource):
 
         for rte, rcfg in rte_cfgs.items():
             if rcfg is None:
-                warn(
+                log.warn(
                     f"Subnet {sn_name} is configured to have a route to "
                     f"a subnet ({rte}) that is not found. This route will "
-                    "be ignored."
+                    "be ignored.",
+                    self,
                 )
                 continue
             # NOTE: special handling for the NAT routes. we


### PR DESCRIPTION
If a file is missing, we use Pulumi log to show the user a warning since the missing file is not fatal to the orchestration of the infrastructure

Resolves #251