### PR TITLE
258 allow metadata to be attached to a collection of uploaded files

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -185,6 +185,9 @@ config:
                 - name: etl-bactopia-results
                   key: glue/etl/etl_bactopia_results.py
                   srcpth: ./assets/etl/etl_bactopia_results.py
+                - name: etl-seqreadarch
+                  key: glue/etl/etl_seqarchive.py
+                  srcpth: ./assets/etl/etl_seqarchive.py
     # `cape-cod:swimlanes` (mapping, required)
     # Contains the configuration for all swimlanes. Swimlanes define logical
     # separations of public, protected and private resources in CAPE. Each
@@ -1205,23 +1208,11 @@ config:
               pipelines:
                   data:
                       etl:
-                          # TODO: TBD
-                          # - name: fastx
-                          #   src: input-raw
-                          #   sink: input-clean
-                          #   script: glue/etl/etl_fasta_fastq.py
-                          #   prefix: fastx
-                          #   suffixes:
-                          #       - gz
-                          #       - fasta
-                          #       - fastq
-                          #   pymodules:
-                          #       - pyfastx==2.1.0
-                          #   max_concurrent_runs: 5
-                          # - name: bactopia-results
-                          #   script: glue/etl/etl_bactopia_results.py
-                          #   src: result-raw
-                          #   sink: result-clean
-                          #   prefix: pipeline-output/bactopia-runs
-                          #   suffixes:
-                          #       - tsv
+                          - name: seqreadarch
+                            src: input-raw
+                            sink: input-clean
+                            script: glue/etl/etl_seqarchive.py
+                            prefix: unprocessed
+                            suffixes:
+                                - gz
+                            max_concurrent_runs: 5

--- a/assets/etl/etl_seqarchive.py
+++ b/assets/etl/etl_seqarchive.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import json
 import tarfile
@@ -7,7 +8,7 @@ from capepy.aws.glue import EtlJob
 etl_job = EtlJob()
 
 # This ETL expects to operate on a tar.gz file containing a metatdata file
-# (meta.json) and a `sequencing` directory containing some number of gzipped 
+# (meta.json) and a `sequencing` directory containing some number of gzipped
 # files fastx files (fasta, fastq). The metadata will be extracted, augmented
 # for later use and then written to the clean data sink. The fastx files will be
 # contcatenated into a single gzipped fastx and also written to the clean data
@@ -17,20 +18,32 @@ etl_job = EtlJob()
 archive_obj_key = etl_job.parameters["OBJECT_KEY"]
 
 sample_archive = etl_job.get_src_file()
+archbio = io.BytesIO(sample_archive)
 
-# baisc tar file
-if not tarfile.is_tarfile(sample_archive):
-   etl_job.logger.error(
-      f"The given sample reads archive {archive_obj_key} is malformed and "
-      f"cannot be opened."
-   )
-   return
+# baisc tar file check
+if not tarfile.is_tarfile(archbio):
+    msg = (
+        f"The given sample reads archive {archive_obj_key} is malformed and "
+        f"cannot be opened."
+    )
+
+    etl_job.logger.error(msg)
+    raise tarfile.ReadError(msg)
+
+archbio.seek(0)
+
+# TODO: not handling errors in format really, which is probably ok as the
+#       exception will get logged in cloudwatch, but the bigger deal is that we
+#       cannot inform the user that the archive was mal-formed at this point.
+
+# NOTE: when processing the streaming body here, the open mode for the tarfile
+#       is "r" *not* "r:gz" (even though we're streaming a tar.gz. If you were
+#       to download the file and write to disk, you would need to go back to
+#       "r:gz"
 
 # open as TarFile and get the meta out
-tf = tarfile.open(fileobj=sample_archive, mode="r:gz")
+tf = tarfile.open(fileobj=archbio, mode="r")
 meta = json.load(tf.extractfile("meta.json"))
-
-etl_job.logger.info(f"Extracted meta from archive: {meta}")
 
 # grab things we need for later naming
 sample_id = meta["sampleId"]
@@ -38,39 +51,47 @@ processed_dt = datetime.datetime.now(datetime.timezone.utc)
 
 # construct the prefix for all files written here
 sink_prefix = (
-    f"{sample_id}/year={processed_dt.year}/{month={processed_dt.month}/"
+    f"{sample_id}/year={processed_dt.year}/month={processed_dt.month}/"
     f"day={processed_dt.day}/hour={processed_dt.hour}/"
-    f"{minute={processed_dt.minute}/second={processed_dt.second}"
+    f"minute={processed_dt.minute}/second={processed_dt.second}"
 )
 
 # start with the gzip files
 with io.BytesIO() as gzbuff:
     # TODO:
-    #   - make sure no possible tar traversal vulns (don't think so since we 
+    #   - make sure no possible tar traversal vulns (don't think so since we
     #     limit to a specific prefix that can't be `/` or `..`)
-    #   - memory requirements for this lambda may be large given we could get 
-    #     enormous archives (possible remediation in attaching filesystem for 
+    #   - memory requirements for this lambda may be large given we could get
+    #     enormous archives (possible remediation in attaching filesystem for
     #     the lambda?)
     #   - direct read->write of the members seems scary
 
     # concat all files in `sequncing` dir
-    for mn in sorted([
-        mn for mn in tf.getnames() if mn.startswith("sequencing/")
-    ]):
+    for mn in sorted(
+        [mn for mn in tf.getnames() if mn.startswith("sequencing/")]
+    ):
         with tf.extractfile(mn) as br:
             gzbuff.write(br.read())
 
     # write out the new clean uber sequencing file
     gzbuff.seek(0)
-    etl_job.write_sink_file(gzbuff, "/".join([sink_prefix, "sequencing-reads.gz"]))
+    etl_job.write_sink_file(
+        gzbuff, "/".join([sink_prefix, "sequencing-reads.gz"])
+    )
 
 # add the s3 path to the concatenated sequencing file into meta
-concat_gz_s3loc = "/".join([f"s3://{etl_job.parameters['SRC_BUCKET_NAME']}/", sink_prefix, "sequencing-reads.gz"])
+concat_gz_s3loc = "/".join(
+    [
+        f"s3://{etl_job.parameters['SRC_BUCKET_NAME']}/",
+        sink_prefix,
+        "sequencing-reads.gz",
+    ]
+)
 meta["sequencing_reads"] = concat_gz_s3loc
 
 # the write meta into clean as well
-with io.BytesIO(json.dumps().encode("utf-8")) as metabuff:
+with io.BytesIO(json.dumps(meta).encode("utf-8")) as metabuff:
     metabuff.seek(0)
     etl_job.write_sink_file(metabuff, "/".join([sink_prefix, "meta.json"]))
 
-
+# TODO: delete raw file?

--- a/assets/etl/etl_seqarchive.py
+++ b/assets/etl/etl_seqarchive.py
@@ -1,0 +1,76 @@
+import io
+import json
+import tarfile
+
+from capepy.aws.glue import EtlJob
+
+etl_job = EtlJob()
+
+# This ETL expects to operate on a tar.gz file containing a metatdata file
+# (meta.json) and a `sequencing` directory containing some number of gzipped 
+# files fastx files (fasta, fastq). The metadata will be extracted, augmented
+# for later use and then written to the clean data sink. The fastx files will be
+# contcatenated into a single gzipped fastx and also written to the clean data
+# sink. The prefix for the clean data will be constructed from the sample_id
+# (from the meta) and the current UTC date/time
+
+archive_obj_key = etl_job.parameters["OBJECT_KEY"]
+
+sample_archive = etl_job.get_src_file()
+
+# baisc tar file
+if not tarfile.is_tarfile(sample_archive):
+   etl_job.logger.error(
+      f"The given sample reads archive {archive_obj_key} is malformed and "
+      f"cannot be opened."
+   )
+   return
+
+# open as TarFile and get the meta out
+tf = tarfile.open(fileobj=sample_archive, mode="r:gz")
+meta = json.load(tf.extractfile("meta.json"))
+
+etl_job.logger.info(f"Extracted meta from archive: {meta}")
+
+# grab things we need for later naming
+sample_id = meta["sampleId"]
+processed_dt = datetime.datetime.now(datetime.timezone.utc)
+
+# construct the prefix for all files written here
+sink_prefix = (
+    f"{sample_id}/year={processed_dt.year}/{month={processed_dt.month}/"
+    f"day={processed_dt.day}/hour={processed_dt.hour}/"
+    f"{minute={processed_dt.minute}/second={processed_dt.second}"
+)
+
+# start with the gzip files
+with io.BytesIO() as gzbuff:
+    # TODO:
+    #   - make sure no possible tar traversal vulns (don't think so since we 
+    #     limit to a specific prefix that can't be `/` or `..`)
+    #   - memory requirements for this lambda may be large given we could get 
+    #     enormous archives (possible remediation in attaching filesystem for 
+    #     the lambda?)
+    #   - direct read->write of the members seems scary
+
+    # concat all files in `sequncing` dir
+    for mn in sorted([
+        mn for mn in tf.getnames() if mn.startswith("sequencing/")
+    ]):
+        with tf.extractfile(mn) as br:
+            gzbuff.write(br.read())
+
+    # write out the new clean uber sequencing file
+    gzbuff.seek(0)
+    etl_job.write_sink_file(gzbuff, "/".join([sink_prefix, "sequencing-reads.gz"]))
+
+# add the s3 path to the concatenated sequencing file into meta
+concat_gz_s3loc = "/".join([f"s3://{etl_job.parameters['SRC_BUCKET_NAME']}/", sink_prefix, "sequencing-reads.gz"])
+meta["sequencing_reads"] = concat_gz_s3loc
+
+# the write meta into clean as well
+with io.BytesIO(json.dumps().encode("utf-8")) as metabuff:
+    metabuff.seek(0)
+    etl_job.write_sink_file(metabuff, "/".join([sink_prefix, "meta.json"]))
+
+


### PR DESCRIPTION
# TO TEST

This may or may not need to be deployed. Test involves using api to upload a file with a specific prefix ("unprocessed") to the correct bucket. A walkthrough may be most expedient, but scripts can be made available if requested.
