### PR TITLE
Automated deployments with triggers

### DIFF
--- a/capeinfra/resources/api.py
+++ b/capeinfra/resources/api.py
@@ -4,6 +4,7 @@ Currently this is geared toward REST apis on AWS API Gateway. HTTP apis are not
 yet supported.
 """
 
+import hashlib
 import json
 from collections import defaultdict
 from collections.abc import Mapping
@@ -508,10 +509,32 @@ class CapeRestApi(CapeComponentResource):
             domain_name: The domain name (e.g. api.cape-dev.org) on which this
                          API will reside.
         """
+        # For aws v1 (rest) apis, once a deployment has been made and
+        # associated with a stage, changes don't necessarily get picked up and
+        # redeployed. In fact in research it seems they rarely do.
+        # Pulumi has this nifty `triggers` concept that appears to be their own
+        # thing they put on top the CloudFormation Deployment concept to address
+        # this problem. You define a mapping of keys and values, and changes to
+        # any of the values causes a redeployment.
+        # We don't want to redeploy unless there has been an actual change of
+        # some sort, so triggering off timestamp (a common pattern for dealing
+        # with this in CloudFormation) in the deployment ID deosn't make too
+        # much sense. So we take the rendered OpenAPI spec that we build our
+        # API from and calculate a sha256 digest from it. We then set that as a
+        # value in the triggers map and anytime there is a change, we redeploy.
+        # This has the downside that *any* change to the OpenAPI spec causes a
+        # redeploy. Even things like comments or whitespace. So keep that in
+        # mind.
+
+        api_sha256 = self._spec.apply(
+            lambda s: hashlib.sha256(f"{s}".encode("utf-8")).hexdigest()
+        )
+
         api_deployment = aws.apigateway.Deployment(
             f"{self.name}-restapi-dplymnt",
             rest_api=self.restapi.id,
-            # TODO: ISSUE #65
+            # ANY change to the value of api_sha256 will cause a redeployment.
+            triggers={"redeploy_on_openapi_spec_sha256_change": api_sha256},
             opts=ResourceOptions(
                 parent=self,
             ),


### PR DESCRIPTION
# TO TEST
***NOTE:*** Seems `pulumi preview` always shows this as a replacement change, but the change only happens when it should. Guessing it's because this isn't actually computing the Output's value at preview time.

* In AWS console for API Gateway under `Stages` for our API, there is a tab in the bottom section for deployment history. Note the currently active deployment id
* As this is already in shared state, a `pulumi up` should not cause a redeployment. 
  * Test that. 
  * `pulumi up` will report a change in the preview, but won't actually change anything.
  * Ensure the active deployment id doesn't change.
* Go into the api spec and comment out an endpoint. Or really make any change that would cause the sha256 to change. Commenting out an endpoint lets you check that the api was actually deployed a bit easier tho. I've been using `rawobjstorage` at the top of the file. If you comment out, be sure to comment out everything up to the next endpoint path.
* `pulumi up` will now report a change *and* make the change.
  * Check the api in AWS console and see that the endpoint is no longer there.
  * Check that the active deployment id is now different.
* Deploy again immediately. See that nothing changes.
* Change things back in the spec and deploy again. It will not go back to a previous id, but it will make a new deployment with a new id and the old functionality.