### PR TITLE
fix: fix nextflow execution to be general for all nextflow commands instead of just bactopia

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1323,7 +1323,7 @@ config:
                           max_vcpus: 16
                 container_images:
                     nextflow_kickstart:
-                        context: ./assets/containers/bactopia-kickstart
+                        context: ./assets/containers/nextflow-kickstart
                         platform: linux/amd64
                 jobs:
                     nextflow:

--- a/assets/analysis-pipelines/bactopia/bactopia-base-3.2.0.json
+++ b/assets/analysis-pipelines/bactopia/bactopia-base-3.2.0.json
@@ -11,14 +11,6 @@
             "-profile": {
                 "const": "aws",
                 "default": "aws"
-            },
-            "--aws_cli_path": {
-                "const": "/home/ec2-user/miniconda/bin/aws",
-                "default": "/home/ec2-user/miniconda/bin/aws"
-            },
-            "--aws_region": {
-                "const": "{{ aws_region }}",
-                "default": "{{ aws_region }}"
             }
         }
     },

--- a/assets/analysis-pipelines/bactopia/bactopia-base-dev.json
+++ b/assets/analysis-pipelines/bactopia/bactopia-base-dev.json
@@ -11,14 +11,6 @@
             "-profile": {
                 "const": "aws",
                 "default": "aws"
-            },
-            "--aws_cli_path": {
-                "const": "/home/ec2-user/miniconda/bin/aws",
-                "default": "/home/ec2-user/miniconda/bin/aws"
-            },
-            "--aws_region": {
-                "const": "{{ aws_region }}",
-                "default": "{{ aws_region }}"
             }
         }
     },

--- a/assets/analysis-pipelines/bactopia/kraken2-bactopia-3.2.0.json
+++ b/assets/analysis-pipelines/bactopia/kraken2-bactopia-3.2.0.json
@@ -1,7 +1,7 @@
 {
     "pipelineType": "nextflow",
-    "pipelineName": "Bactopia ONT Sample",
-    "pipelineDescription": "Execute Bactopia's ONT sample sequencing workflow with v3.2.0",
+    "pipelineName": "Bactopia Kraken2",
+    "pipelineDescription": "Execute Bactopia's Kraken2 workflow with the development release",
     "project": "bactopia/bactopia",
     "version": "v3.2.0",
     "inherits": ["bactopia-base-3.2.0"],
@@ -10,40 +10,35 @@
         "type": "object",
         "allOf": [{ "$ref": "#/$defs/bactopia-base-3.2.0" }],
         "properties": {
+            "--wf": {
+                "const": "kraken2",
+                "default": "kraken2"
+            },
             "--max_cpus": {
                 "type": "integer",
                 "title": "Max CPUs",
                 "minimum": 1,
-                "default": 8
+                "default": 2
             },
             "--max_memory": {
                 "type": "string",
                 "title": "Max Memory",
-                "default": "24.GB"
+                "default": "8.GB"
             },
-            "--ont": {
+            "--bactopia": {
                 "type": "string",
-                "title": "ONT"
-            },
-            "--sample": {
-                "type": "string",
-                "title": "Sample Name"
-            },
-            "--outdir": {
-                "type": "string",
-                "title": "S3 Location of the output directory"
+                "title": "Bactopia Output Directory"
             }
         },
         "unevaluatedProperties": false,
-        "required": ["--sample", "--ont", "--outdir"]
+        "required": ["--bactopia"]
     },
     "uiSchema": {
         "type": "VerticalLayout",
         "elements": [
             { "type": "Control", "scope": "#/properties/--max_cpus" },
             { "type": "Control", "scope": "#/properties/--max_memory" },
-            { "type": "Control", "scope": "#/properties/--ont" },
-            { "type": "Control", "scope": "#/properties/--sample" }
+            { "type": "Control", "scope": "#/properties/--bactopia" }
         ]
     },
     "submission": {

--- a/assets/analysis-pipelines/bactopia/ont-bactopia-dev.json
+++ b/assets/analysis-pipelines/bactopia/ont-bactopia-dev.json
@@ -28,10 +28,14 @@
             "--sample": {
                 "type": "string",
                 "title": "Sample Name"
+            },
+            "--outdir": {
+                "type": "string",
+                "title": "S3 Location of the output directory"
             }
         },
         "unevaluatedProperties": false,
-        "required": ["--sample"]
+        "required": ["--sample", "--ont", "--outdir"]
     },
     "uiSchema": {
         "type": "VerticalLayout",

--- a/assets/api/capi/capi-openapi-301.yaml.j2
+++ b/assets/api/capi/capi-openapi-301.yaml.j2
@@ -1229,15 +1229,6 @@ paths:
                                     type: string
                                     description:
                                         The version of the pipeline to run
-                                outputPath:
-                                    type: string
-                                    description: >
-                                        The S3 location to put pipeline output.
-                                        Assumes permissions are set correctly.
-{#
-    TODO: ISSUE #TBD all below fields are specific to bactopia right now. also, the
-          descriptions are bunk if we keep using these params
-#}
                                 nextflowOptions:
                                     type: string
                                     description: The command line flags to pass to Nextflow

--- a/assets/api/capi/handlers/submit_dap_run.py
+++ b/assets/api/capi/handlers/submit_dap_run.py
@@ -42,6 +42,10 @@ def index_handler(event, context):
         output_path = body["outputPath"]
         nf_opts = body["nextflowOptions"]
         nf_opts = (
+            # TODO: REMOVE THESE BACTOPIA SPECIFIC THINGS SOMEHOW
+            # - outdir is pretty natural, it can be passed in with nf_opts
+            # - aws_queue maybe should be passed with an environment variable
+            #   evaluated automatically with something like `${NF_OPTS@P}` (bash v4.4+)
             f"--outdir {output_path} --aws_queue {job_queue_name} {nf_opts}"
         )
 
@@ -53,6 +57,7 @@ def index_handler(event, context):
                 "environment": [
                     {"name": "PIPELINE", "value": pipeline_project},
                     {"name": "PIPELINE_VERSION", "value": pipeline_version},
+                    {"name": "PIPELINE_QUEUE", "value": job_queue_name},
                     {"name": "NF_OPTS", "value": nf_opts},
                 ]
             },

--- a/assets/api/capi/handlers/submit_dap_run.py
+++ b/assets/api/capi/handlers/submit_dap_run.py
@@ -39,15 +39,7 @@ def index_handler(event, context):
 
         pipeline_project = body["pipelineProject"]
         pipeline_version = body["pipelineVersion"]
-        output_path = body["outputPath"]
         nf_opts = body["nextflowOptions"]
-        nf_opts = (
-            # TODO: REMOVE THESE BACTOPIA SPECIFIC THINGS SOMEHOW
-            # - outdir is pretty natural, it can be passed in with nf_opts
-            # - aws_queue maybe should be passed with an environment variable
-            #   evaluated automatically with something like `${NF_OPTS@P}` (bash v4.4+)
-            f"--outdir {output_path} --aws_queue {job_queue_name} {nf_opts}"
-        )
 
         response = batch_client.submit_job(
             jobName=f"nextflow-{context.aws_request_id}",

--- a/assets/containers/bactopia-kickstart/entrypoint.sh
+++ b/assets/containers/bactopia-kickstart/entrypoint.sh
@@ -13,6 +13,7 @@ fi
 if [[ -n ${PIPELINE_VERSION} ]]; then
     PIPELINE_VERSION="-r ${PIPELINE_VERSION}"
 fi
+PIPELINE_QUEUE=${PIPELINE_QUEUE}
 NF_OPTS=${NF_OPTS}
 
 # Get AWS Region if not already set
@@ -38,9 +39,26 @@ cd /scratch
 BUCKET_TEMP_NAME=nextflow-spot-batch-temp-${AWS_BATCH_JOB_ID}
 aws --region "${AWS_REGION}" s3 mb s3://"${BUCKET_TEMP_NAME}"
 
+# TODO: allow user to pass in a specific nextflow confix string and use that
+# instead, evaluating environment variables with something like
+# `${NEXTFLOW_CONFIG@P} (requires bash v4.4+)
+cat >/nextflow.config <<EOF
+process {
+    executor = 'awsbatch'
+    queue = '${PIPELINE_QUEUE}'
+}
+aws {
+    region = '${AWS_REGION}'
+    batch {
+        cliPath = '/home/ec2-user/miniconda/bin/aws'
+    }
+}
+EOF
+
 # Execute Nextflow
 BACTOPIA_CACHEDIR=s3://${BUCKET_TEMP_NAME} nextflow \
     run "${PIPELINE}" ${PIPELINE_VERSION} \
+    -c /nextflow.config \
     -work-dir s3://"${BUCKET_TEMP_NAME}" \
     ${NF_OPTS}
 

--- a/assets/containers/bactopia-kickstart/entrypoint.sh
+++ b/assets/containers/bactopia-kickstart/entrypoint.sh
@@ -56,6 +56,8 @@ aws {
 EOF
 
 # Execute Nextflow
+# TODO: remove abctopia cachedir environment variable? We would have to move it
+# somewhere butit doesn't pose any issues with other workflows for now
 BACTOPIA_CACHEDIR=s3://${BUCKET_TEMP_NAME} nextflow \
     run "${PIPELINE}" ${PIPELINE_VERSION} \
     -c /nextflow.config \

--- a/assets/containers/nextflow-kickstart/Dockerfile
+++ b/assets/containers/nextflow-kickstart/Dockerfile
@@ -1,6 +1,7 @@
 FROM amazoncorretto:21.0.8
 
 # Install Nextflow
+ENV NXF_VER=25.10.4
 RUN curl -s https://get.nextflow.io | bash
 RUN chmod +x nextflow
 RUN mv nextflow /usr/local/bin

--- a/assets/containers/nextflow-kickstart/entrypoint.sh
+++ b/assets/containers/nextflow-kickstart/entrypoint.sh
@@ -39,7 +39,7 @@ cd /scratch
 BUCKET_TEMP_NAME=nextflow-spot-batch-temp-${AWS_BATCH_JOB_ID}
 aws --region "${AWS_REGION}" s3 mb s3://"${BUCKET_TEMP_NAME}"
 
-# TODO: allow user to pass in a specific nextflow confix string and use that
+# TODO: allow user to pass in a specific nextflow config string and use that
 # instead, evaluating environment variables with something like
 # `${NEXTFLOW_CONFIG@P} (requires bash v4.4+)
 cat >/nextflow.config <<EOF
@@ -56,8 +56,8 @@ aws {
 EOF
 
 # Execute Nextflow
-# TODO: remove abctopia cachedir environment variable? We would have to move it
-# somewhere butit doesn't pose any issues with other workflows for now
+# TODO: remove bactopia cachedir environment variable? We would have to move it
+# somewhere but it doesn't pose any issues with other workflows for now
 BACTOPIA_CACHEDIR=s3://${BUCKET_TEMP_NAME} nextflow \
     run "${PIPELINE}" ${PIPELINE_VERSION} \
     -c /nextflow.config \

--- a/capeinfra/swimlane.py
+++ b/capeinfra/swimlane.py
@@ -200,7 +200,7 @@ class ScopedSwimlane(CapeComponentResource):
             az: The name of the availability zone to create the nat in.
             subnet: The subnet to associate with an internet facing NAT GW.
         Returns:
-            A new list of routes for the subent with the internet egress route
+            A new list of routes for the subnet with the internet egress route
             first in the list.
         """
 


### PR DESCRIPTION
This generalizes our Dockerimage for kicking off nextflow jobs to support all Nextflow commands rather than being specific to Bactopia.

_NOTE:_ this is nextflow 25. Tested with the new Nextflow 26 + Bactopia v4.0.0 and there are some breaking changes we need to figure out.

Breaking Changes:

- The `/dap/submit` API endpoint no longer accepts `outputPath` for submitting a DAP pipeline. This is now handled with more generic Nextflow argument flags, for example adding `--outdir <output_directory>` to the `nextflowOptions` string instead for the Bactopia ONT workflow
- There are now more workflows:
    - `bactopia-base-{dev,3.2.0}` - there as a very generic "run any bactopia command". parameter schema allows user to add whatever parameters they want and it will validate
    - `bactopia-ont-{dev,3.2.0}` - for running our ONT pipeline with specific arguments specified out. This enforces basically a canned bactopia command for our ONT sequence processing
    - `bactopia-kraken2-{dev,3.2.0}` - for kicking off kraken2 with bactopia on some bactopia output. Similar in advice above regarding the ONT pipeline
- When using the nextflow job definition in AWS batch, you must pass in `PIPELINE_QUEUE` to tell it which queue to submit netflow pipeline steps to (the `/dap/submit` endpoint does this automagically)

Still TODO:

- Persistent storage volume for "shared large files" into the nextflow containers. This will be used for kraken2 database so it doesn't need to be downloaded each time. (hopefully this is one day generalized so pipeline designers can put something in an s3 bucket somewhere and say 'please mount this when executing my pipeline, its very important')

Example job definition submission parameters:

- `PIPELINE`: `bactopia/bactopia`
- `PIPELINE_VERSION`: `v3.2.0`
- `PIPELINE_QUEUE`: `ccd-pvsl-analysis-btch-jobq-somehash`
- `NF_OPTS`: `--outdir s3://path/to/bactopia/pipeline-output -profile aws --max_cpus 8 --max_memory 24.GB --ont s3://path/to/sequencing-reads.gz --sample sample1`