### PR TITLE
updated ami for OPA (now uses ami for v1.18.0)

### DIFF
--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1234,7 +1234,7 @@ config:
                           - cognito
                     - name: "opa"
                       short_name: "opa"
-                      image: "ami-05080e4998b881ee0"
+                      image: "ami-07b9e418d53f44854"
                       public_ip: False
                       instance_type: "t3a.medium"
                       subnet_types:


### PR DESCRIPTION
# TO TEST

This has been deployed, so can be tested by SSH'ing into the OPA boxen and running `opa version` and ensuring the value is similar to (version should match)

```
[ec2-user@ip-10-0-124-47 ~]$ opa version
Version: 1.18.0
Build Commit: cc2c5c60a4c486f15a5e8de457e96ed0fefaf5fe-dirty
Build Timestamp: 2026-06-25T17:10:29Z
Build Hostname: 
Go Version: go1.26.4
Platform: linux/amd64
Rego Version: v1
WebAssembly: available
```