### PR TITLE
feat(api): attribute workflow runs to the triggering cognito user

### DIFF
--- a/.llm-wiki/wiki/analyses/workflow-user-attribution.md
+++ b/.llm-wiki/wiki/analyses/workflow-user-attribution.md
@@ -1,0 +1,79 @@
+---
+type: analysis
+title: "Workflow user attribution (conf.cape)"
+slug: workflow-user-attribution
+status: stable
+confidence: high
+created: 2026-07-20
+updated: 2026-07-20
+tags: ["api", "airflow", "mwaa", "workflows", "authorizer", "security", "capi"]
+---
+
+# Workflow user attribution (`conf.cape`)
+
+How the capi API records "which user triggered an Airflow DAG run" and exposes a
+per-user run list, given the MWAA integration constraints. See
+[[entities/assets-capi-handlers]] and [[entities/assets-api-authorizer-and-spec]]
+for the code, and [[entities/airflow-module]] / [[entities/cape-rest-api-module]]
+for the surrounding infrastructure.
+
+## Constraint
+
+The capi Lambdas reach Airflow through `mwaa_client.invoke_rest_api`, which is
+authenticated to MWAA by the shared API Lambda IAM role (a single service
+principal) - not as the end user. Airflow therefore cannot populate its native
+`triggering_user_name` with the Cognito user; it would only ever see the service
+identity. Faithfully setting the native field would require presenting each end
+user's identity to Airflow's auth manager, a large change to the auth model.
+
+## Decision
+
+Record the user in the DAG run `conf` under a namespaced `cape` block, which is
+persisted in Airflow state, shown in the Airflow UI, and returned by the Airflow
+REST API - with no database dependency.
+
+- `conf.cape = { triggering_user_id, triggering_user_name }`. The id is the
+  stable Cognito `sub` (used for filtering); the name is email/username (for
+  human-readable display).
+- Identity is resolved server-side, never trusted from the client.
+
+## Flow
+
+1. `authz/default_apigw_authorizer.py` decodes the `Authorization` bearer token
+   and injects `triggering_user_id` / `triggering_user_name` into the authorizer
+   `context`. (Signature verification is still TODO - see the authorizer page.)
+2. `handlers/post_workflow_run.py` reads that context via
+   `caller_identity_from_event`, then `apply_cape_identity` strips any
+   client-supplied `conf.cape` (anti-spoofing) and stamps the resolved identity.
+   It also sets the DAG run `note` to `Triggered by <user>` so admins see the
+   owner in the Airflow runs list without opening `conf`.
+3. `handlers/get_workflow_runs.py` (route `GET /workflows/runs`, handler key
+   `get_workflow_runs_handler`) resolves the caller (`caller_user_id`, with a
+   `userId` query-string fallback for pre-authorizer/dev calls), lists each
+   DAG's recent runs, and returns only those where
+   `conf.cape.triggering_user_id` matches (`filter_runs_for_user`).
+
+## IAM / wiring notes
+
+- The new handler shares the API Lambda role, which already gets MWAA
+  `invoke_rest_api` permission via the managed policy attachment from
+  `MwaaEnvironment` (see `capeinfra/swimlanes/private.py`), so no IAM change was
+  needed. `MWAA_ENVIRONMENT` is injected into all capi handlers via the shared
+  `env_vars` in `capeinfra/resources/api.py`.
+- Registered in `Pulumi.cape-cod-dev.yaml` and `Pulumi.cape-cod-public.yaml`
+  and in `capi-openapi-301.yaml.j2` (with the standard OPTIONS CORS mock).
+
+## Follow-ups / risks
+
+- Authorizer does not verify the JWT signature yet; harden before production or
+  switch to a managed Cognito JWT authorizer (would need Cognito issuer/JWKS
+  config wired into the currently env-var-less authorizer Lambda).
+- Per-user listing filters in the proxy because Airflow has no server-side
+  filter on a `conf` value (true in every Airflow version). Runs are fetched via
+  Airflow 3's cross-DAG list endpoint `GET /dags/~/dagRuns/list` (the `~`
+  wildcard covers all DAGs), paged at 100 up to a scan cap, so it is one
+  paginated stream rather than one request per DAG. Large run volumes may still
+  warrant a database-backed ownership index (the CAPE environment DB) later;
+  this scalability follow-up is fully specified in cape-ph/cape-frontend#30.
+
+Related: [[syntheses/assets-subsystem]], [[concepts/coding-style-and-tooling]].

--- a/.llm-wiki/wiki/analyses/workflow-user-attribution.md
+++ b/.llm-wiki/wiki/analyses/workflow-user-attribution.md
@@ -5,7 +5,7 @@ slug: workflow-user-attribution
 status: stable
 confidence: high
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 tags: ["api", "airflow", "mwaa", "workflows", "authorizer", "security", "capi"]
 ---
 
@@ -25,6 +25,31 @@ principal) - not as the end user. Airflow therefore cannot populate its native
 `triggering_user_name` with the Cognito user; it would only ever see the service
 identity. Faithfully setting the native field would require presenting each end
 user's identity to Airflow's auth manager, a large change to the auth model.
+
+## Why not authenticate the real user into Airflow?
+
+A natural question is whether we could pass the Cognito bearer token through to
+Airflow so it authenticates as the actual user (and populates its native
+triggering-user field). On MWAA this is not achievable:
+
+- MWAA's Airflow web/REST auth is AWS IAM-based (access is granted via
+  `mwaa:CreateWebLoginToken` / `airflow:InvokeRestApi`), not our Cognito user
+  pool. MWAA does not let you swap the Airflow auth backend to an OIDC/Cognito
+  provider, and nothing in `capeinfra/pipeline/airflow.py` wires one up.
+- The frontend never talks to Airflow directly. It calls the capi API
+  (API Gateway -> Lambda), and the Lambda reaches Airflow with
+  `mwaa_client.invoke_rest_api`, authenticated by SigV4 using the Lambda
+  execution role (mapped to the Airflow `Op` role in `private.py`). The Cognito
+  token is consumed and discarded at the API Gateway edge and never travels to
+  Airflow, so Airflow only ever sees that single service principal.
+- Getting a true per-user Airflow identity would require self-managed Airflow
+  (not MWAA) with a Cognito OIDC auth backend, plus the frontend hitting Airflow
+  directly or the API impersonating the user via token passthrough - a large
+  infra shift that abandons MWAA's managed benefits.
+
+So resolving identity at the Cognito-authenticated API edge and stamping it into
+`conf.cape` is the correct pattern under the MWAA constraint, not a workaround
+for a missing feature.
 
 ## Decision
 
@@ -66,8 +91,9 @@ REST API - with no database dependency.
 ## Follow-ups / risks
 
 - Authorizer does not verify the JWT signature yet; harden before production or
-  switch to a managed Cognito JWT authorizer (would need Cognito issuer/JWKS
-  config wired into the currently env-var-less authorizer Lambda).
+  switch to a native API Gateway Cognito User Pools authorizer (AWS handles
+  verification/JWKS; handlers would then read `requestContext.authorizer.claims`).
+  This migration is fully specified in cape-ph/cape-cod#352.
 - Per-user listing filters in the proxy because Airflow has no server-side
   filter on a `conf` value (true in every Airflow version). Runs are fetched via
   Airflow 3's cross-DAG list endpoint `GET /dags/~/dagRuns/list` (the `~`

--- a/.llm-wiki/wiki/analyses/workflow-user-attribution.md
+++ b/.llm-wiki/wiki/analyses/workflow-user-attribution.md
@@ -94,12 +94,19 @@ REST API - with no database dependency.
   switch to a native API Gateway Cognito User Pools authorizer (AWS handles
   verification/JWKS; handlers would then read `requestContext.authorizer.claims`).
   This migration is fully specified in cape-ph/cape-cod#352.
-- Per-user listing filters in the proxy because Airflow has no server-side
-  filter on a `conf` value (true in every Airflow version). Runs are fetched via
-  Airflow 3's cross-DAG list endpoint `GET /dags/~/dagRuns/list` (the `~`
-  wildcard covers all DAGs), paged at 100 up to a scan cap, so it is one
-  paginated stream rather than one request per DAG. Large run volumes may still
-  warrant a database-backed ownership index (the CAPE environment DB) later;
-  this scalability follow-up is fully specified in cape-ph/cape-frontend#30.
+- Per-user listing filters in the proxy. Runs are fetched via Airflow 3's
+  cross-DAG list endpoint `GET /dags/~/dagRuns` (the `~` wildcard covers all
+  DAGs), ordered by `-run_after` (`logical_date` is nullable for API-triggered
+  runs in Airflow 3) and paged at 100 up to a scan cap, so it is one paginated
+  stream rather than one request per DAG. Airflow 3.0.6 exposes a `conf_contains`
+  query filter (substring CONTAINS on the serialized `conf`); the handler passes
+  the caller's user id as `conf_contains` to prefilter server-side, then re-
+  checks `conf.cape.triggering_user_id` exactly in the proxy so a coincidental
+  substring match cannot leak another user's run. Note: the older
+  `GET /dags/~/dagRuns/list` batch endpoint does not exist in Airflow 3's v2 API
+  and returns a 4xx (surfaced as `RestApiClientException`). Large run volumes may
+  still warrant a database-backed ownership index (the CAPE environment DB)
+  later; this scalability follow-up is fully specified in
+  cape-ph/cape-frontend#30.
 
 Related: [[syntheses/assets-subsystem]], [[concepts/coding-style-and-tooling]].

--- a/.llm-wiki/wiki/analyses/workflow-user-attribution.md
+++ b/.llm-wiki/wiki/analyses/workflow-user-attribution.md
@@ -72,10 +72,11 @@ REST API - with no database dependency.
    `caller_identity_from_event`, then `apply_cape_identity` strips any
    client-supplied `conf.cape` (anti-spoofing) and stamps the resolved identity.
 3. `handlers/get_workflow_runs.py` (route `GET /workflows/runs`, handler key
-   `get_workflow_runs_handler`) resolves the caller (`caller_user_id`, with a
-   `userId` query-string fallback for pre-authorizer/dev calls), lists recent
-   runs across all DAGs, and returns only those where
-   `conf.cape.triggering_user_id` matches (`filter_runs_for_user`).
+   `get_workflow_runs_handler`) resolves the caller (`caller_user_id`, from the
+   authorizer context only - no client-supplied override), lists recent runs
+   across all DAGs, and returns only those where `conf.cape.triggering_user_id`
+   matches (`filter_runs_for_user`). It returns 401 when the caller cannot be
+   resolved.
 
 ## IAM / wiring notes
 

--- a/.llm-wiki/wiki/analyses/workflow-user-attribution.md
+++ b/.llm-wiki/wiki/analyses/workflow-user-attribution.md
@@ -71,6 +71,8 @@ REST API - with no database dependency.
 2. `handlers/post_workflow_run.py` reads that context via
    `caller_identity_from_event`, then `apply_cape_identity` strips any
    client-supplied `conf.cape` (anti-spoofing) and stamps the resolved identity.
+   It returns 401 when no `triggering_user_id` resolves, so a run is never
+   triggered unattributed (matching the list path).
 3. `handlers/get_workflow_runs.py` (route `GET /workflows/runs`, handler key
    `get_workflow_runs_handler`) resolves the caller (`caller_user_id`, from the
    authorizer context only - no client-supplied override), lists recent runs

--- a/.llm-wiki/wiki/analyses/workflow-user-attribution.md
+++ b/.llm-wiki/wiki/analyses/workflow-user-attribution.md
@@ -13,9 +13,10 @@ tags: ["api", "airflow", "mwaa", "workflows", "authorizer", "security", "capi"]
 
 How the capi API records "which user triggered an Airflow DAG run" and exposes a
 per-user run list, given the MWAA integration constraints. See
-[[entities/assets-capi-handlers]] and [[entities/assets-api-authorizer-and-spec]]
-for the code, and [[entities/airflow-module]] / [[entities/cape-rest-api-module]]
-for the surrounding infrastructure.
+[[entities/assets-capi-handlers]] and
+[[entities/assets-api-authorizer-and-spec]] for the code, and
+[[entities/airflow-module]] / [[entities/cape-rest-api-module]] for the
+surrounding infrastructure.
 
 ## Constraint
 
@@ -36,8 +37,8 @@ triggering-user field). On MWAA this is not achievable:
   `mwaa:CreateWebLoginToken` / `airflow:InvokeRestApi`), not our Cognito user
   pool. MWAA does not let you swap the Airflow auth backend to an OIDC/Cognito
   provider, and nothing in `capeinfra/pipeline/airflow.py` wires one up.
-- The frontend never talks to Airflow directly. It calls the capi API
-  (API Gateway -> Lambda), and the Lambda reaches Airflow with
+- The frontend never talks to Airflow directly. It calls the capi API (API
+  Gateway -> Lambda), and the Lambda reaches Airflow with
   `mwaa_client.invoke_rest_api`, authenticated by SigV4 using the Lambda
   execution role (mapped to the Airflow `Op` role in `private.py`). The Cognito
   token is consumed and discarded at the API Gateway edge and never travels to
@@ -70,12 +71,10 @@ REST API - with no database dependency.
 2. `handlers/post_workflow_run.py` reads that context via
    `caller_identity_from_event`, then `apply_cape_identity` strips any
    client-supplied `conf.cape` (anti-spoofing) and stamps the resolved identity.
-   It also sets the DAG run `note` to `Triggered by <user>` so admins see the
-   owner in the Airflow runs list without opening `conf`.
 3. `handlers/get_workflow_runs.py` (route `GET /workflows/runs`, handler key
    `get_workflow_runs_handler`) resolves the caller (`caller_user_id`, with a
-   `userId` query-string fallback for pre-authorizer/dev calls), lists each
-   DAG's recent runs, and returns only those where
+   `userId` query-string fallback for pre-authorizer/dev calls), lists recent
+   runs across all DAGs, and returns only those where
    `conf.cape.triggering_user_id` matches (`filter_runs_for_user`).
 
 ## IAM / wiring notes
@@ -85,28 +84,29 @@ REST API - with no database dependency.
   `MwaaEnvironment` (see `capeinfra/swimlanes/private.py`), so no IAM change was
   needed. `MWAA_ENVIRONMENT` is injected into all capi handlers via the shared
   `env_vars` in `capeinfra/resources/api.py`.
-- Registered in `Pulumi.cape-cod-dev.yaml` and `Pulumi.cape-cod-public.yaml`
-  and in `capi-openapi-301.yaml.j2` (with the standard OPTIONS CORS mock).
+- Registered in `Pulumi.cape-cod-dev.yaml` and `Pulumi.cape-cod-public.yaml` and
+  in `capi-openapi-301.yaml.j2` (with the standard OPTIONS CORS mock).
 
 ## Follow-ups / risks
 
 - Authorizer does not verify the JWT signature yet; harden before production or
   switch to a native API Gateway Cognito User Pools authorizer (AWS handles
-  verification/JWKS; handlers would then read `requestContext.authorizer.claims`).
-  This migration is fully specified in cape-ph/cape-cod#352.
+  verification/JWKS; handlers would then read
+  `requestContext.authorizer.claims`). This migration is fully specified in
+  cape-ph/cape-cod#352.
 - Per-user listing filters in the proxy. Runs are fetched via Airflow 3's
   cross-DAG list endpoint `GET /dags/~/dagRuns` (the `~` wildcard covers all
   DAGs), ordered by `-run_after` (`logical_date` is nullable for API-triggered
   runs in Airflow 3) and paged at 100 up to a scan cap, so it is one paginated
-  stream rather than one request per DAG. Airflow 3.0.6 exposes a `conf_contains`
-  query filter (substring CONTAINS on the serialized `conf`); the handler passes
-  the caller's user id as `conf_contains` to prefilter server-side, then re-
-  checks `conf.cape.triggering_user_id` exactly in the proxy so a coincidental
-  substring match cannot leak another user's run. Note: the older
-  `GET /dags/~/dagRuns/list` batch endpoint does not exist in Airflow 3's v2 API
-  and returns a 4xx (surfaced as `RestApiClientException`). Large run volumes may
-  still warrant a database-backed ownership index (the CAPE environment DB)
-  later; this scalability follow-up is fully specified in
+  stream rather than one request per DAG. Airflow 3.0.6 exposes a
+  `conf_contains` query filter (substring CONTAINS on the serialized `conf`);
+  the handler passes the caller's user id as `conf_contains` to prefilter
+  server-side, then re- checks `conf.cape.triggering_user_id` exactly in the
+  proxy so a coincidental substring match cannot leak another user's run. Note:
+  the older `GET /dags/~/dagRuns/list` batch endpoint does not exist in Airflow
+  3's v2 API and returns a 4xx (surfaced as `RestApiClientException`). Large run
+  volumes may still warrant a database-backed ownership index (the CAPE
+  environment DB) later; this scalability follow-up is fully specified in
   cape-ph/cape-frontend#30.
 
 Related: [[syntheses/assets-subsystem]], [[concepts/coding-style-and-tooling]].

--- a/.llm-wiki/wiki/concepts/agent-playbook.md
+++ b/.llm-wiki/wiki/concepts/agent-playbook.md
@@ -5,7 +5,7 @@ slug: agent-playbook
 status: stable
 confidence: high
 created: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-21
 tags: ["playbook", "workflow", "start-here", "safety", "onboarding"]
 ---
 
@@ -34,14 +34,19 @@ through `CapeComponentResource` + `CapeConfig` (see
 4. Edit minimally: smallest correct change, matching existing conventions (see
    [[concepts/coding-style-and-tooling]]).
 5. Validate: `pulumi preview` on a local stack and `pytest` (see
-   [[concepts/testing-and-pulumi-preview-workflow]]).
+   [[concepts/testing-and-pulumi-preview-workflow]]). Before a deploy, run
+   `pulumi preview --diff` against the target stack and reconcile every planned
+   action against the changes actually made in the branch.
 6. Record: `wiki_retro` durable insights, `wiki_observe` running notes; update
    the affected page if structure changed.
 
 ## Hard rules
 
 - NEVER run `pulumi up` or any deploy/destroy. Local verification is
-  `pulumi preview` (local, non-production stack) + `pytest` only.
+  `pulumi preview` (local, non-production stack) + `pytest` only. Deployment
+  preparation includes running `pulumi preview --diff` and reviewing the diff
+  against the intended change before the user deploys; the review is the agent's
+  job, the deploy is the user's.
 - Tooling is fixed: Python -> black + isort at 80 cols; YAML/JSON/Markdown ->
   Prettier; types -> Pyright `basic`. Do NOT add ruff, flake8, biome, eslint, or
   mypy. Do not change CI/tooling without explicit instruction.

--- a/.llm-wiki/wiki/concepts/agent-playbook.md
+++ b/.llm-wiki/wiki/concepts/agent-playbook.md
@@ -38,7 +38,9 @@ through `CapeComponentResource` + `CapeConfig` (see
    `pulumi preview --diff` against the target stack and reconcile every planned
    action against the changes actually made in the branch.
 6. Record: `wiki_retro` durable insights, `wiki_observe` running notes; update
-   the affected page if structure changed.
+   the affected page if structure changed. Commit the resulting
+   `.llm-wiki/wiki/**` changes (authored pages and new source pages) in the same
+   commit as the code they describe.
 
 ## Hard rules
 

--- a/.llm-wiki/wiki/concepts/testing-and-pulumi-preview-workflow.md
+++ b/.llm-wiki/wiki/concepts/testing-and-pulumi-preview-workflow.md
@@ -5,7 +5,7 @@ slug: testing-and-pulumi-preview-workflow
 status: stable
 confidence: high
 created: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-21
 tags: ["testing", "pulumi", "preview", "pytest", "safety", "workflow"]
 ---
 
@@ -43,6 +43,49 @@ is roughly:
 
 Prefer running `pulumi preview` against a local, non-production stack. Do not
 run it in a way that mutates a shared/live stack's config.
+
+## Reviewing the `--diff` before a deploy
+
+Whenever a change touches the Pulumi program or the `assets/**` it deploys,
+`pulumi preview --diff` is a required deployment-preparation step, run and
+reviewed before the user performs the real deploy. The point is to confirm the
+planned change matches the intended scope, not just that the program compiles.
+
+- Run `pulumi preview --diff` against the target stack (e.g. `-s cape-cod-dev`).
+  `--diff` expands per-resource property changes so create/update/replace/delete
+  and the specific fields are visible, not just a summary count.
+- Reconcile every reported action against the changes actually made in the
+  branch. Each create/update should trace to a real edit; there should be no
+  unexplained churn.
+- Treat replacements or deletions of shared resources as stop-and-investigate
+  signals. A replace on a stateful resource (bucket, database, queue) can be
+  destructive; understand why before the user deploys.
+- Only once the diff is understood and matches the intended change does the user
+  run the deploy. Agents still never run `pulumi up` - the review is the agent's
+  job, the deploy is the user's.
+
+### Known benign recurring drift
+
+Some resources show up in nearly every `cape-cod-dev` preview regardless of the
+branch under review. These are expected and are not a reason to hold a deploy on
+their own - when a preview contains only these plus the branch's intended
+changes, the diff is clean:
+
+- `cognito/identityProvider` `GTRI-SSO` (`cape-idp-SAML-GTRI-SSO`): its
+  `providerDetails` (SAML `ActiveEncryptionCertificate`,
+  `SLORedirectBindingURI`, `SSORedirectBindingURI`) recompute to `[unknown]` on
+  essentially every preview. This SAML metadata always recomputes; it is
+  expected.
+- `docker-build:index:Image` `nextflow_kickstart`: its `contextHash` changes
+  regularly, which shows as an image rebuild. This is normal churn, not
+  necessarily a concern. The rebuild cascades to the batch `jobDefinition`
+  (`ccd-pvsl-nextflow-jobdef` revision bump) and the IAM policy that references
+  that revision ARN (`ccd-pvsl-nextflow-jobdef-pssrl-plcy`), so those two
+  updates typically ride along with it.
+
+Still scan them each time - the point is they are known-benign by default, not
+that they should be ignored. Anything outside this set and the branch's own
+changes is what warrants investigation.
 
 ## The pytest suite
 

--- a/.llm-wiki/wiki/entities/assets-api-authorizer-and-spec.md
+++ b/.llm-wiki/wiki/entities/assets-api-authorizer-and-spec.md
@@ -13,18 +13,28 @@ tags: ["api", "authorizer", "openapi", "security", "assets"]
 
 ## `authz/default_apigw_authorizer.py`
 
-A Lambda request authorizer for API Gateway. IMPORTANT: it is currently a
-test/sample stub that ALLOWS EVERYTHING - `lambda_handler` unconditionally
-returns `generate_policy("*", "Allow", "*")`. It is heavily TODO-commented:
+A Lambda request authorizer for API Gateway. It makes an allow-all access
+decision (real allow/deny policy still TODO), but it now resolves the caller's
+Cognito identity from the `Authorization` bearer token and passes it downstream
+to endpoint handlers via the authorizer `context`:
 
-- Intended to become a real authorizer (check caller identity via headers /
-  query / path params / stage vars, build a scoped `execute-api:Invoke` policy
-  from the method ARN, deny with `raise Exception("Unauthorized")` for a 401).
-- Currently prints debug info and returns an allow-all policy with placeholder
-  context. Treat this as a known security gap, not production authz.
+- `get_bearer_token(headers)` extracts the token (case-insensitive header,
+  tolerates a bare token with no `Bearer` prefix).
+- `decode_jwt_claims(token)` base64url-decodes the JWT payload. IMPORTANT: it
+  does NOT verify the signature yet (module TODO) - treat identity as
+  authenticated-by-transport-only until signature verification or a managed
+  Cognito JWT authorizer is added.
+- `identity_context_from_claims(claims)` maps `sub` ->
+  `triggering_user_id` and `email`/`cognito:username` -> `triggering_user_name`.
+- `generate_policy(principalId, effect, resource, context=None)` returns the IAM
+  policy plus the string-valued `context` map.
 
-`generate_policy(principalId, effect, resource)` builds the IAM policy document
-response (adapted from the AWS Lambda authorizer example).
+Handlers read that identity from `event.requestContext.authorizer` (e.g.
+`post_workflow_run.py` stamps it into the DAG run `conf.cape`; `get_workflow_runs.py`
+filters runs by it). See [[analyses/workflow-user-attribution]]. Anonymous/
+unparseable tokens still get an allow with an empty context (rollout safety).
+NOTE: the authorizer Lambda is created with no env vars; signature verification
+would need Cognito config (JWKS/issuer) wired in.
 
 Wired via `CapeRestApi._create_api_authorizer_lambdas` (see
 [[entities/cape-rest-api-module]]).
@@ -69,6 +79,7 @@ CORS headers (the ISSUE #141 bypass; see [[entities/assets-capi-handlers]]).
 | `/workflows/trigger`           | `post_workflow_run_handler`               | `post_workflow_run.py`               |
 | `/workflows/halt`              | `patch_workflow_run_handler`              | `patch_workflow_run.py`              |
 | `/workflows/run`               | `get_workflow_run_handler`                | `get_workflow_run.py`                |
+| `/workflows/runs`              | `get_workflow_runs_handler`               | `get_workflow_runs.py`               |
 | `/workflows/tasks`             | `get_workflow_tasks_handler`              | `get_workflow_tasks.py`              |
 | `/workflows/run/taskinstances` | `get_workflow_run_task_instances_handler` | `get_workflow_run_task_instances.py` |
 

--- a/.llm-wiki/wiki/entities/assets-capi-handlers.md
+++ b/.llm-wiki/wiki/entities/assets-capi-handlers.md
@@ -54,9 +54,18 @@ the rendered OpenAPI spec and created as a Lambda by `CapeRestApi` (see
 - `get_workflow_dags.py` - available Airflow DAGs.
 - `get_workflow_pipeline_profiles.py` - DAP profiles used by a workflow.
 - `get_workflow_run.py` - a specific workflow run.
+- `get_workflow_runs.py` - the calling user's workflow runs. Lists recent runs
+  across all DAGs via Airflow's cross-DAG endpoint `GET /dags/~/dagRuns/list`
+  (paged), and returns only those whose `conf.cape.triggering_user_id` matches
+  the caller (resolved from the API authorizer context; see
+  [[analyses/workflow-user-attribution]]).
 - `get_workflow_run_task_instances.py` - task instances for a run.
 - `get_workflow_tasks.py` - tasks for a workflow.
-- `post_workflow_run.py` - create a workflow run.
+- `post_workflow_run.py` - create a workflow run. Stamps the triggering user
+  onto the DAG run `conf` under `conf.cape` (`triggering_user_id` /
+  `triggering_user_name`) from the authorizer context, strips any
+  client-supplied `cape` (anti-spoofing), and sets a `Triggered by <user>`
+  run note. See [[analyses/workflow-user-attribution]].
 - `patch_workflow_run.py` - update a workflow run.
 
 ## User attribute handlers

--- a/.llm-wiki/wiki/entities/assets-capi-handlers.md
+++ b/.llm-wiki/wiki/entities/assets-capi-handlers.md
@@ -55,9 +55,10 @@ the rendered OpenAPI spec and created as a Lambda by `CapeRestApi` (see
 - `get_workflow_pipeline_profiles.py` - DAP profiles used by a workflow.
 - `get_workflow_run.py` - a specific workflow run.
 - `get_workflow_runs.py` - the calling user's workflow runs. Lists recent runs
-  across all DAGs via Airflow's cross-DAG endpoint `GET /dags/~/dagRuns/list`
-  (paged), and returns only those whose `conf.cape.triggering_user_id` matches
-  the caller (resolved from the API authorizer context; see
+  across all DAGs via Airflow 3's cross-DAG endpoint `GET /dags/~/dagRuns`
+  (server-side `conf_contains` prefilter, `order_by=-run_after`, paged), and
+  returns only those whose `conf.cape.triggering_user_id` matches the caller
+  (resolved from the API authorizer context; see
   [[analyses/workflow-user-attribution]]).
 - `get_workflow_run_task_instances.py` - task instances for a run.
 - `get_workflow_tasks.py` - tasks for a workflow.

--- a/.llm-wiki/wiki/entities/assets-capi-handlers.md
+++ b/.llm-wiki/wiki/entities/assets-capi-handlers.md
@@ -64,9 +64,9 @@ the rendered OpenAPI spec and created as a Lambda by `CapeRestApi` (see
 - `get_workflow_tasks.py` - tasks for a workflow.
 - `post_workflow_run.py` - create a workflow run. Stamps the triggering user
   onto the DAG run `conf` under `conf.cape` (`triggering_user_id` /
-  `triggering_user_name`) from the authorizer context, strips any
-  client-supplied `cape` (anti-spoofing), and sets a `Triggered by <user>`
-  run note. See [[analyses/workflow-user-attribution]].
+  `triggering_user_name`) from the authorizer context and strips any
+  client-supplied `cape` (anti-spoofing). See
+  [[analyses/workflow-user-attribution]].
 - `patch_workflow_run.py` - update a workflow run.
 
 ## User attribute handlers

--- a/.llm-wiki/wiki/sources/obs-2026-07-20-implemented-workflow-user-attribution-conf-cape.md
+++ b/.llm-wiki/wiki/sources/obs-2026-07-20-implemented-workflow-user-attribution-conf-cape.md
@@ -1,0 +1,16 @@
+---
+type: source
+title: "Observation: Implemented workflow user attribution via Airflow conf.cape (authorizer + capi handlers)"
+slug: obs-2026-07-20-implemented-workflow-user-attribution-conf-cape
+status: observation
+created: 2026-07-20
+updated: 2026-07-20
+relevance: high
+observed_at: 2026-07-20T00:00:00.000Z
+tags: ["airflow", "mwaa", "workflows", "authorizer", "capi", "security", "cape-cod", "implemented"]
+source_context: "Implementing per-user workflow run attribution across cape-cod + cape-frontend"
+---
+# Observation: Implemented workflow user attribution via Airflow conf.cape (authorizer + capi handlers)
+
+Implemented server-side per-user attribution for Airflow DAG runs in cape-cod. Because capi reaches MWAA via mwaa_client.invoke_rest_api authenticated by the single shared API Lambda IAM role, Airflow's native triggering_user_name can't reflect the Cognito user; recorded the user in DAG run conf.cape = {triggering_user_id (Cognito sub), triggering_user_name (email/username)} instead (persisted in Airflow state, visible in UI, returned by REST API, no DB dependency). Changes: (1) assets/api/authz/default_apigw_authorizer.py - now decodes the Authorization bearer JWT (get_bearer_token, decode_jwt_claims, identity_context_from_claims: sub->triggering_user_id, email/cognito:username->triggering_user_name) and injects identity into the authorizer context; still allow-all and NO JWT signature verification yet (TODO: verify vs Cognito JWKS or switch to managed Cognito JWT authorizer; authorizer Lambda currently has no env vars). (2) assets/api/capi/handlers/post_workflow_run.py - caller_identity_from_event reads requestContext.authorizer; apply_cape_identity strips client-supplied conf.cape (anti-spoof) and stamps resolved identity; also sets run note "Triggered by <user>". (3) NEW assets/api/capi/handlers/get_workflow_runs.py - GET /workflows/runs, handler key get_workflow_runs_handler; caller_user_id (authorizer + userId qsp fallback), iterates /dags then /dags/{id}/dagRuns (limit 100, order_by -logical_date), filters by conf.cape.triggering_user_id (run_belongs_to_user/filter_runs_for_user), returns {dag_runs, total_entries}; 401 when caller unresolved. (4) capi-openapi-301.yaml.j2 - added /workflows/runs GET + OPTIONS CORS mock. (5) Pulumi.cape-cod-dev.yaml + Pulumi.cape-cod-public.yaml - registered get_workflow_runs_handler (capi-all layer, index.index_handler, py3.10). No IAM change needed: shared API role already has MWAA invoke via MwaaEnvironment managed policy attachment (private.py); MWAA_ENVIRONMENT injected via shared env_vars (resources/api.py). Tests: tests/test_workflow_user_attribution.py - 34 pass (loads single-file lambdas via importlib). Follow-up risks: JWT signature not verified; N+1 DAG iteration paged at 100 (large volumes may need DB-backed ownership index in CAPE env DB). Frontend (cape-frontend) sends the bearer token and consumes GET /workflows/runs, replacing cookie-based tracking.
+*Relevance: high*

--- a/.llm-wiki/wiki/sources/obs-2026-07-28-pulumi-preview-diff-for-airflow-user-info-7-feature-changes-.md
+++ b/.llm-wiki/wiki/sources/obs-2026-07-28-pulumi-preview-diff-for-airflow-user-info-7-feature-changes-.md
@@ -1,0 +1,38 @@
+---
+type: source
+title: "Observation: pulumi preview --diff for airflow_user_info: 7 feature changes + 4 pre-existing drift"
+slug: obs-2026-07-28-pulumi-preview-diff-for-airflow-user-info-7-feature-changes-
+status: observation
+created: 2026-07-28
+updated: 2026-07-28
+relevance: high
+observed_at: 2026-07-28T14:30:32.019Z
+tags: ["pulumi", "preview", "deploy", "cape-cod", "airflow-user-attribution", "capi"]
+source_context: "Deploy verification for workflow user attribution (cape-cod airflow_user_info)"
+---
+# ⭐ Observation: pulumi preview --diff for airflow_user_info: 7 feature changes + 4 pre-existing drift
+Ran `pulumi preview --diff -s cape-cod-dev` for branch airflow_user_info (workflow user attribution). 11 changes total: 2 create, 8 update, 1 replace, 460 unchanged. Split cleanly into two groups.
+
+Feature changes (7, all trace to the branch):
+- update lambda ccd-pvsl-capi-api-default-hndlr (code -> assets/api/authz/default_apigw_authorizer.py)
+- update lambda ccd-pvsl-capi-api-postdagrun (code -> assets/api/capi/handlers/post_workflow_run.py)
+- create lambda ccd-pvsl-capi-api-getdagruns (code -> assets/api/capi/handlers/get_workflow_runs.py; shares role ccd-pvsl-capi-api-lmbd-role, env includes MWAA_ENVIRONMENT=ccd-pvsl-airflow-env-mwaa-env, layer capi-all:7, python3.10)
+- create lambda permission ccd-pvsl-capi-api-getdagruns-allowlmbd (API GW invoke)
+- update apigateway restApi body (new /workflows/runs route); body renders as a whole-block change because the recomputed spec embeds the new lambda invoke ARN which is [unknown] until create - normal for aws_proxy specs, not a real deletion
+- replace apigateway deployment (redeploy_on_openapi_spec_sha256_change trigger changed because spec sha256 changed)
+- update apigateway stage (deployment ref follows the replace)
+
+Pre-existing drift (4, NOT from this branch - git diff confirms branch only touches wiki, Pulumi config, authorizer, openapi spec, the two handlers, tests):
+- update cognito IdentityProvider GTRI-SSO (providerDetails ActiveEncryptionCertificate + SLO/SSORedirectBindingURI recompute to [unknown])
+- update docker-build Image nextflow_kickstart (contextHash change -> rebuild)
+- update batch jobDefinition ccd-pvsl-nextflow-jobdef (containerProperties recompute, revision bump, follows image rebuild)
+- update iam policy ccd-pvsl-nextflow-jobdef-pssrl-plcy (references new job-definition revision ARN)
+
+Preview is read-only against the shared s3://cape-pulumi-state backend; ran with valid creds (account 767397883306). Deploy remains the user's step.
+*Relevance: high*
+
+*Context: Deploy verification for workflow user attribution (cape-cod airflow_user_info)*
+
+*Tags: pulumi preview deploy cape-cod airflow-user-attribution capi*
+---
+*Observed: 2026-07-28T14:30:32.019Z*

--- a/.llm-wiki/wiki/sources/obs-2026-07-30-trigger-path-now-gates-on-resolvable-caller-identity-401-mat.md
+++ b/.llm-wiki/wiki/sources/obs-2026-07-30-trigger-path-now-gates-on-resolvable-caller-identity-401-mat.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Trigger path now gates on resolvable caller identity (401), matching list path"
+slug: obs-2026-07-30-trigger-path-now-gates-on-resolvable-caller-identity-401-mat
+status: observation
+created: 2026-07-30
+updated: 2026-07-30
+relevance: high
+observed_at: 2026-07-30T17:21:51.616Z
+tags: ["cape-cod", "api", "auth", "airflow", "attribution", "pr-353"]
+source_context: "PR #353 review response - workflow-run attribution auth gating"
+---
+# ⭐ Observation: Trigger path now gates on resolvable caller identity (401), matching list path
+In cape-cod PR #353 (branch airflow_user_info), addressed a review from thecaffiend about asymmetric auth enforcement. Previously POST /workflows/trigger (assets/api/capi/handlers/post_workflow_run.py) triggered DAGs even with no resolvable identity (run just went unattributed), while GET /workflows/runs 401s. Fixed by gating the trigger: index_handler now resolves identity via caller_identity_from_event and returns 401 with CORS headers when triggering_user_id is absent, before calling MWAA. Response headers were hoisted into a shared resp_headers reused by the 401 and success returns. Also removed the earlier userId query-string fallback from get_workflow_runs.caller_user_id (spoofing risk). Added handler tests (monkeypatching post_workflow_run.boto3.client) asserting 401-without-identity never calls MWAA and stamp-then-trigger works with an identity; suite now 38 tests. Caveat: authorizer is still decode-only (no JWT signature verification), so the gate only requires a decodable token carrying a sub, not a verified user; re-key off verified claims when the native Cognito authorizer (#352) lands - noted on that issue. Commit ff81e14 (amended, force-pushed).
+*Relevance: high*
+
+*Context: PR #353 review response - workflow-run attribution auth gating*
+
+*Tags: cape-cod api auth airflow attribution pr-353*
+---
+*Observed: 2026-07-30T17:21:51.616Z*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,23 @@ findings.
 - With the `@zosmaai/pi-llm-wiki` extension, prefer its tools (`wiki_recall`,
   `wiki_retro`, `wiki_ensure_page`); they maintain `meta/` automatically.
   Without it, edit the markdown directly and leave `meta/` alone.
+
+## Deployment Preparation
+
+CAPE Cod deploys live, shared infrastructure. Agents never run `pulumi up` or
+any deploy/destroy - the real deploy is the user's step. As a normal part of
+preparing (and doing) a deploy together, run `pulumi preview --diff` against the
+target stack and evaluate the output before the user deploys:
+
+- Run `pulumi preview --diff -s <stack>` (e.g. `cape-cod-dev`). The `--diff`
+  flag expands per-resource property changes so create/update/replace/delete and
+  the specific fields are visible, not just a summary count.
+- Reconcile every planned action against the changes actually made in the
+  branch. Each create/update should trace to a real edit; unexplained churn is a
+  stop-and-investigate signal.
+- Treat replacements or deletions of shared/stateful resources (buckets,
+  databases, queues) as destructive until proven otherwise; understand why
+  before the user deploys.
+- Only once the diff is understood and matches the intended scope does the user
+  run the deploy. See
+  `.llm-wiki/wiki/concepts/testing-and-pulumi-preview-workflow.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ findings.
   `[[folder/page]]`, and cite sources.
 - Never edit `.llm-wiki/raw/**` (immutable captures) or `.llm-wiki/meta/**`
   (generated index). `meta/` is gitignored and rebuilt locally.
+- Commit authored `.llm-wiki/wiki/**` changes (including new `wiki_observe` /
+  `wiki_retro` source pages) in the same commit as the code they describe, so
+  the knowledge lands alongside the change. `meta/`, `raw/`, `outputs/`, and
+  `.discoveries/` are gitignored and stay out of commits.
 - With the `@zosmaai/pi-llm-wiki` extension, prefer its tools (`wiki_recall`,
   `wiki_retro`, `wiki_ensure_page`); they maintain `meta/` automatically.
   Without it, edit the markdown directly and leave `meta/` alone.

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -835,6 +835,19 @@ config:
                                 description: "getdags Lambda Function"
                                 memory_size: 128
                                 timeout: 10
+                          - id: "get_workflow_runs_handler"
+                            name: "getdagruns"
+                            code: "assets/api/capi/handlers/get_workflow_runs.py"
+                            layers:
+                                - capi-all
+                            funct_args:
+                                handler: "index.index_handler"
+                                runtime: "python3.10"
+                                architectures:
+                                    - "x86_64"
+                                description: "getdagruns Lambda Function"
+                                memory_size: 128
+                                timeout: 30
                           - id: "get_workflow_tasks_handler"
                             name: "getdagtasks"
                             code: "assets/api/capi/handlers/get_workflow_tasks.py"

--- a/Pulumi.cape-cod-public.yaml
+++ b/Pulumi.cape-cod-public.yaml
@@ -818,6 +818,19 @@ config:
                   description: "getdags Lambda Function"
                   memory_size: 128
                   timeout: 10
+              - id: "get_workflow_runs_handler"
+                name: "getdagruns"
+                code: "assets/api/capi/handlers/get_workflow_runs.py"
+                layers:
+                  - capi-all
+                funct_args:
+                  handler: "index.index_handler"
+                  runtime: "python3.10"
+                  architectures:
+                    - "x86_64"
+                  description: "getdagruns Lambda Function"
+                  memory_size: 128
+                  timeout: 30
               - id: "get_workflow_tasks_handler"
                 name: "getdagtasks"
                 code: "assets/api/capi/handlers/get_workflow_tasks.py"

--- a/assets/api/authz/default_apigw_authorizer.py
+++ b/assets/api/authz/default_apigw_authorizer.py
@@ -1,64 +1,143 @@
-# Basic lambda request authorizer for testing API gateway authz
-# TODO:
-# - once shown to work in basics, we should take this from test/sample status to
-#   a real authz implementation
-# - AWS docs suggest using request authorizers over token authorizers as the
-#   former can be used for finer grained policies and caching. we should figure
-#   out which better suits our needs, but for now we're following the advice.
+# Lambda request authorizer for the CAPE API.
+#
+# Responsibilities:
+# - Decide allow/deny for the caller (currently allow-all; real policy TBD).
+# - Resolve the caller's identity from the Cognito bearer token and pass it
+#   downstream to endpoint handlers via the authorizer `context`. Handlers read
+#   this identity (e.g. to stamp the triggering user onto an Airflow DAG run)
+#   instead of trusting client-supplied values.
+#
+# TODO (authz hardening, tracked for follow-up):
+# - This does NOT verify the JWT signature yet. It decodes the token payload for
+#   identity only. Before production, either verify the signature against the
+#   Cognito JWKS here, or replace this lambda authorizer with a managed Cognito
+#   (JWT) authorizer on the API. Until then, treat the resolved identity as
+#   authenticated-by-transport-only, not cryptographically verified.
+# - Move to real allow/deny decisions once identity is trustworthy.
+
+import base64
+import binascii
+import json
 
 
 def lambda_handler(event, context):
+    """API Gateway request authorizer entrypoint.
 
-    # TODO: remove this debug printing
-    print(f"Lambda authz event: {event}")
-    print(f"Lambda authz context: {context}")
+    Returns an IAM policy plus a `context` map carrying the caller identity
+    (as strings, per API Gateway's authorizer-context constraints).
+    """
+    headers = event.get("headers") or {}
+    identity = identity_context_from_headers(headers)
 
-    # figure out the caller from the request
-    # TODO: we can use headers, query string params, stage variables, path
-    #       parameters, and context variables to figure out who's calling. need
-    #       to figure out the best mix for all our services. client side (api
-    #       caller) has the ability to set path params, headers and query
-    #       params. all others are set by AWS
+    # principalId should be a stable identifier for the caller when we have one.
+    principal_id = identity.get("triggering_user_id") or "unknown"
 
-    headers = event.get("headers", "NO HEADERS")
-    query_params = event.get("queryStringParameters", "NO QUERY STRING PARAMS")
-    path_params = event.get("pathParameters", "NO PATH PARAMS")
-    stage_vars = event.get("stageVariables", "NO STAGE VARIABLES")
-
-    # TODO: remove this debug printing
-    print(f"Lambda authz headers: {headers}")
-    print(f"Lambda authz query_params: {query_params}")
-    print(f"Lambda authz path_params: {path_params}")
-    print(f"Lambda authz stage_vars: {stage_vars}")
-
-    # Parse the input for the parameter values
-
-    # TODO:
-    # - can do things like get the methodARN out of the event, use that to get
-    #   the identifier of the APIGW, account number, region, restapi id, stage,
-    #   method, etc as part of what to grant access to in the returned policy
-
-    # TODO: Check the values we determine we need against some TBD criteria and
-    #       return either an allow or deny policy. E.g. for this simple test,
-    #       probably want to check that a username (of the caller) provided
-    #       matches the name of the user we want to allow, and otherwise deny.
-    #       When denying, do so by raising `Exception("Unauthorized")` (which
-    #       gives a 401)
-
-    # TODO: right now, all shall pass. if this works, need to get front ends
-    #       passing in headers and such for this authorizer to use
-    return generate_policy("*", "Allow", "*")
+    return generate_policy(principal_id, "Allow", "*", context=identity)
 
 
-# Shamelessly taken from the example in the AWS docs for Lambda Authorizers.
-# Changed to not be javascript style and to reduce redundancy...
-def generate_policy(principalId, effect, resource):
-    """"""
-    authz_resp = {}
-    authz_resp["principalId"] = principalId
+def get_bearer_token(headers):
+    """Extract a bearer token from request headers (case-insensitive).
+
+    :param headers: The request headers mapping (may be None).
+    :return: The raw token string, or None if not present.
+    """
+    if not headers:
+        return None
+
+    # API Gateway header casing is not guaranteed; match case-insensitively.
+    auth_value = None
+    for key, value in headers.items():
+        if key.lower() == "authorization":
+            auth_value = value
+            break
+
+    if not auth_value:
+        return None
+
+    parts = auth_value.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+
+    # Allow a bare token with no scheme prefix as a fallback.
+    return auth_value.strip() or None
+
+
+def decode_jwt_claims(token):
+    """Decode the (unverified) claim set from a JWT.
+
+    NOTE: This does not validate the signature. See module TODO.
+
+    :param token: A JWT string (header.payload.signature).
+    :return: A dict of claims, or {} if the token can't be parsed.
+    """
+    if not token or not isinstance(token, str):
+        return {}
+
+    segments = token.split(".")
+    if len(segments) < 2:
+        return {}
+
+    payload_segment = segments[1]
+    # JWT uses base64url without padding; restore padding before decoding.
+    padding = "=" * (-len(payload_segment) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(payload_segment + padding)
+        claims = json.loads(decoded)
+    except (ValueError, binascii.Error, json.JSONDecodeError):
+        return {}
+
+    return claims if isinstance(claims, dict) else {}
+
+
+def identity_context_from_claims(claims):
+    """Build the downstream authorizer context from Cognito claims.
+
+    :param claims: The decoded JWT claims dict.
+    :return: A dict with `triggering_user_id` and `triggering_user_name` keys for
+             any values we could resolve. Missing values are omitted so callers
+             can distinguish "unknown".
+    """
+    context = {}
+
+    # `sub` is the stable Cognito user id; prefer it for the filterable id.
+    user_id = claims.get("sub")
+    if user_id:
+        context["triggering_user_id"] = str(user_id)
+
+    # Human-readable name for admin/UI display: email, then cognito username.
+    user_name = (
+        claims.get("email")
+        or claims.get("cognito:username")
+        or claims.get("username")
+    )
+    if user_name:
+        context["triggering_user_name"] = str(user_name)
+
+    return context
+
+
+def identity_context_from_headers(headers):
+    """Resolve caller identity context directly from request headers.
+
+    Convenience wrapper composing token extraction and claim decoding.
+    """
+    token = get_bearer_token(headers)
+    claims = decode_jwt_claims(token)
+    return identity_context_from_claims(claims)
+
+
+def generate_policy(principal_id, effect, resource, context=None):
+    """Build an API Gateway authorizer response.
+
+    :param principal_id: Identifier for the caller.
+    :param effect: "Allow" or "Deny".
+    :param resource: The resource ARN(s) the policy applies to.
+    :param context: Optional string-valued map passed to downstream handlers.
+    """
+    authz_resp = {"principalId": principal_id}
 
     if effect and resource:
-        policy_doc = {
+        authz_resp["policyDocument"] = {
             "Version": "2012-10-17",
             "Statement": [
                 {
@@ -69,13 +148,7 @@ def generate_policy(principalId, effect, resource):
             ],
         }
 
-        authz_resp["policyDocument"] = policy_doc
-
-    # TODO: sample context, this is garbage data ATM
-    authz_resp["context"] = {
-        "some_ctx_str": "some_ctx_str_val",
-        "some_ctx_int": 42,
-        "some_ctx_bool": True,
-    }
+    # API Gateway only supports string/number/bool context values (no nesting).
+    authz_resp["context"] = context or {}
 
     return authz_resp

--- a/assets/api/capi/capi-openapi-301.yaml.j2
+++ b/assets/api/capi/capi-openapi-301.yaml.j2
@@ -1785,6 +1785,65 @@ paths:
                 passthroughBehavior: "when_no_match"
                 timeoutInMillis: 29000
                 type: "mock"
+    /workflows/runs:
+        get:
+            parameters:
+                - in: query
+                  name: userId
+                  schema:
+                    type: string
+                    description:
+                        Optional fallback caller id used only when the API
+                        authorizer has not injected the caller identity. In
+                        normal operation the triggering user is resolved from
+                        the Authorization token by the authorizer.
+                  required: false
+            responses:
+                "200":
+                    description: "Success"
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                description:
+                                    The calling user's workflow runs. Contains a
+                                    `dag_runs` array (Airflow DAG run objects)
+                                    and a `total_entries` count.
+                                additionalProperties: true
+                "401":
+                    description: Caller identity could not be resolved.
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/responses/AirflowErrorDetailStrResp"
+                                    - $ref: "#/components/responses/AirflowErrorDetailObjResp"
+                "500":
+                    description:
+                        Server error while fetching workflow runs.
+            x-amazon-apigateway-integration:
+                httpMethod: "POST"
+                uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/{{ handlers['get_workflow_runs_handler'] }}/invocations"
+                passthroughBehavior: "when_no_match"
+                timeoutInMillis: 29000
+                type: "aws_proxy"
+        options:
+            responses:
+                "200":
+                    $ref: "#/components/responses/200OptionsCors"
+            x-amazon-apigateway-integration:
+                responses:
+                    default:
+                        statusCode: "200"
+                        responseParameters:
+                            method.response.header.Access-Control-Allow-Methods: "'OPTIONS,GET'"
+                            method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+                            method.response.header.Access-Control-Allow-Origin: "'*'"
+                requestTemplates:
+                    application/json: "{'statusCode':200}"
+                passthroughBehavior: "when_no_match"
+                timeoutInMillis: 29000
+                type: "mock"
     /workflows/tasks:
         get:
             parameters:

--- a/assets/api/capi/capi-openapi-301.yaml.j2
+++ b/assets/api/capi/capi-openapi-301.yaml.j2
@@ -1787,17 +1787,6 @@ paths:
                 type: "mock"
     /workflows/runs:
         get:
-            parameters:
-                - in: query
-                  name: userId
-                  schema:
-                    type: string
-                    description:
-                        Optional fallback caller id used only when the API
-                        authorizer has not injected the caller identity. In
-                        normal operation the triggering user is resolved from
-                        the Authorization token by the authorizer.
-                  required: false
             responses:
                 "200":
                     description: "Success"

--- a/assets/api/capi/handlers/get_workflow_runs.py
+++ b/assets/api/capi/handlers/get_workflow_runs.py
@@ -1,0 +1,195 @@
+"""Lambda function for listing the airflow workflow runs a user triggered.
+
+This endpoint backs the "my workflows" view. It is a proxy to Airflow that
+returns only the DAG runs whose `conf.cape.triggering_user_id` matches the
+calling user, so the frontend does not have to track submitted runs client-side.
+
+Ownership is recorded at trigger time by `post_workflow_run.py` (see
+`conf.cape`), resolved from the API Gateway authorizer context.
+"""
+
+import json
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+from capepy.aws.utils import decode_error
+
+# Keep in sync with post_workflow_run.CAPE_CONF_KEY.
+CAPE_CONF_KEY = "cape"
+
+# Page size when listing runs across all DAGs (Airflow caps page limit at 100).
+DAG_RUNS_PAGE_LIMIT = 100
+# Safety cap on how many recent runs we scan while filtering by owner. Airflow
+# has no server-side filter for a `conf` value, so we page through the most
+# recent runs and match `conf.cape` here.
+MAX_RUNS_SCANNED = 1000
+
+
+def caller_user_id(event):
+    """Resolve the calling user's stable id.
+
+    Prefers the identity injected by the API Gateway authorizer
+    (`requestContext.authorizer.triggering_user_id`). Falls back to a `userId`
+    query string parameter to support local/dev calls before the authorizer is
+    fully wired.
+
+    :param event: The API Gateway proxy event.
+    :return: The user id string, or None if it cannot be resolved.
+    """
+    request_context = event.get("requestContext") or {}
+    authorizer = request_context.get("authorizer") or {}
+    user_id = authorizer.get("triggering_user_id")
+
+    if not user_id:
+        qsp = event.get("queryStringParameters") or {}
+        user_id = qsp.get("userId")
+
+    return str(user_id) if user_id else None
+
+
+def run_belongs_to_user(run, user_id):
+    """Return True if a DAG run was triggered by the given user.
+
+    :param run: A single Airflow DAG run object (dict).
+    :param user_id: The stable user id to match against `conf.cape`.
+    """
+    if not isinstance(run, dict) or not user_id:
+        return False
+
+    conf = run.get("conf")
+    if not isinstance(conf, dict):
+        return False
+
+    cape = conf.get(CAPE_CONF_KEY)
+    if not isinstance(cape, dict):
+        return False
+
+    return cape.get("triggering_user_id") == user_id
+
+
+def filter_runs_for_user(runs, user_id):
+    """Filter a list of DAG runs down to those triggered by the user.
+
+    :param runs: Iterable of DAG run dicts.
+    :param user_id: The stable user id to match against.
+    :return: A list of matching runs (order preserved).
+    """
+    return [run for run in (runs or []) if run_belongs_to_user(run, user_id)]
+
+
+def _list_all_dag_runs(mwaa_client, env_name):
+    """List recent DAG runs across all DAGs, most recent first.
+
+    Uses Airflow's cross-DAG list endpoint (`/dags/~/dagRuns/list`; the `~`
+    wildcard means "all DAGs") so every DAG is covered by a single paginated
+    stream instead of one request per DAG. Paging stops once MAX_RUNS_SCANNED
+    runs have been seen or Airflow reports no more entries.
+    """
+    runs = []
+    offset = 0
+
+    while offset < MAX_RUNS_SCANNED:
+        response = mwaa_client.invoke_rest_api(
+            Name=env_name,
+            Path="/dags/~/dagRuns/list",
+            Method="GET",
+            QueryParameters={
+                "limit": DAG_RUNS_PAGE_LIMIT,
+                "offset": offset,
+                "order_by": "-logical_date",
+            },
+        )
+        data = response["RestApiResponse"]
+        page = data.get("dag_runs", [])
+        runs.extend(page)
+
+        offset += DAG_RUNS_PAGE_LIMIT
+        if not page or offset >= data.get("total_entries", 0):
+            break
+
+    return runs
+
+
+def index_handler(event, context):
+    """Handler for GET of the calling user's workflow runs.
+
+    Lists recent DAG runs across all DAGs in one paginated stream and returns
+    only those triggered by the caller (matched on
+    `conf.cape.triggering_user_id`).
+
+    TODO: Airflow has no server-side filter for a `conf` value, so ownership
+          filtering is done here after fetching recent runs. For large run
+          volumes this should move to a database-backed ownership index (the
+          CAPE environment DB).
+
+    :param event: The event object that contains the HTTP request.
+    :param context: Context object.
+    """
+
+    env_name = os.getenv("MWAA_ENVIRONMENT")
+
+    # TODO: add this to capepy
+    mwaa_client = boto3.client("mwaa")
+
+    resp_headers = {
+        "Content-Type": "application/json",
+        # TODO: ISSUE #141 CORS bypass. We do not want this long term. See the
+        #       other capi handlers for the full context on this.
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "OPTIONS,GET",
+    }
+
+    try:
+        user_id = caller_user_id(event)
+
+        if not user_id:
+            # Without a resolvable caller we cannot scope the list. Return a 401
+            # so the frontend can surface an auth problem rather than an empty
+            # (and misleading) success.
+            return {
+                "statusCode": 401,
+                "headers": resp_headers,
+                "body": json.dumps(
+                    {
+                        "message": (
+                            "Unable to resolve the calling user. A valid "
+                            "Authorization token is required."
+                        )
+                    }
+                ),
+            }
+
+        all_runs = _list_all_dag_runs(mwaa_client, env_name)
+        matching_runs = filter_runs_for_user(all_runs, user_id)
+
+        # Airflow already orders newest-first; sort defensively in case a page
+        # boundary or backend quirk perturbs the order.
+        matching_runs.sort(
+            key=lambda run: run.get("logical_date") or "",
+            reverse=True,
+        )
+
+        return {
+            "statusCode": 200,
+            "headers": resp_headers,
+            "body": json.dumps(
+                {
+                    "dag_runs": matching_runs,
+                    "total_entries": len(matching_runs),
+                }
+            ),
+        }
+    except ClientError as err:
+        code, message = decode_error(err)
+
+        msg = (
+            f"Error during fetch of workflow runs from airflow. "
+            f"{code} {message}"
+        )
+
+        return {
+            "statusCode": 500,
+            "body": msg,
+        }

--- a/assets/api/capi/handlers/get_workflow_runs.py
+++ b/assets/api/capi/handlers/get_workflow_runs.py
@@ -28,12 +28,12 @@ MAX_RUNS_SCANNED = 1000
 
 
 def caller_user_id(event):
-    """Resolve the calling user's stable id.
+    """Resolve the calling user's stable id from the authorizer context.
 
-    Prefers the identity injected by the API Gateway authorizer
-    (`requestContext.authorizer.triggering_user_id`). Falls back to a `userId`
-    query string parameter to support local/dev calls before the authorizer is
-    fully wired.
+    The API Gateway authorizer resolves the Cognito user from the bearer token
+    and injects `triggering_user_id` into `requestContext.authorizer`. Only that
+    server-side value is trusted; the caller cannot supply their own id, so
+    there is no query-string override.
 
     :param event: The API Gateway proxy event.
     :return: The user id string, or None if it cannot be resolved.
@@ -41,10 +41,6 @@ def caller_user_id(event):
     request_context = event.get("requestContext") or {}
     authorizer = request_context.get("authorizer") or {}
     user_id = authorizer.get("triggering_user_id")
-
-    if not user_id:
-        qsp = event.get("queryStringParameters") or {}
-        user_id = qsp.get("userId")
 
     return str(user_id) if user_id else None
 

--- a/assets/api/capi/handlers/get_workflow_runs.py
+++ b/assets/api/capi/handlers/get_workflow_runs.py
@@ -78,27 +78,36 @@ def filter_runs_for_user(runs, user_id):
     return [run for run in (runs or []) if run_belongs_to_user(run, user_id)]
 
 
-def _list_all_dag_runs(mwaa_client, env_name):
+def _list_all_dag_runs(mwaa_client, env_name, conf_contains=None):
     """List recent DAG runs across all DAGs, most recent first.
 
-    Uses Airflow's cross-DAG list endpoint (`/dags/~/dagRuns/list`; the `~`
+    Uses Airflow 3's cross-DAG list endpoint (`GET /dags/~/dagRuns`; the `~`
     wildcard means "all DAGs") so every DAG is covered by a single paginated
-    stream instead of one request per DAG. Paging stops once MAX_RUNS_SCANNED
+    stream instead of one request per DAG. When `conf_contains` is provided it
+    is passed as the server-side `conf_contains` filter so Airflow only returns
+    runs whose serialized `conf` contains that value (the caller's user id),
+    which keeps the scanned volume small. Paging stops once MAX_RUNS_SCANNED
     runs have been seen or Airflow reports no more entries.
+
+    Runs are ordered by `-run_after`; `logical_date` is nullable in Airflow 3
+    for API-triggered runs, so it is not a reliable sort key.
     """
     runs = []
     offset = 0
 
+    query_parameters = {
+        "limit": DAG_RUNS_PAGE_LIMIT,
+        "order_by": "-run_after",
+    }
+    if conf_contains:
+        query_parameters["conf_contains"] = conf_contains
+
     while offset < MAX_RUNS_SCANNED:
         response = mwaa_client.invoke_rest_api(
             Name=env_name,
-            Path="/dags/~/dagRuns/list",
+            Path="/dags/~/dagRuns",
             Method="GET",
-            QueryParameters={
-                "limit": DAG_RUNS_PAGE_LIMIT,
-                "offset": offset,
-                "order_by": "-logical_date",
-            },
+            QueryParameters={**query_parameters, "offset": offset},
         )
         data = response["RestApiResponse"]
         page = data.get("dag_runs", [])
@@ -161,13 +170,19 @@ def index_handler(event, context):
                 ),
             }
 
-        all_runs = _list_all_dag_runs(mwaa_client, env_name)
+        all_runs = _list_all_dag_runs(
+            mwaa_client, env_name, conf_contains=user_id
+        )
+        # `conf_contains` is a substring prefilter; re-check ownership exactly
+        # so a coincidental substring match cannot leak another user's run.
         matching_runs = filter_runs_for_user(all_runs, user_id)
 
         # Airflow already orders newest-first; sort defensively in case a page
         # boundary or backend quirk perturbs the order.
         matching_runs.sort(
-            key=lambda run: run.get("logical_date") or "",
+            key=lambda run: run.get("run_after")
+            or run.get("logical_date")
+            or "",
             reverse=True,
         )
 
@@ -191,5 +206,6 @@ def index_handler(event, context):
 
         return {
             "statusCode": 500,
-            "body": msg,
+            "headers": resp_headers,
+            "body": json.dumps({"message": msg}),
         }

--- a/assets/api/capi/handlers/get_workflow_runs.py
+++ b/assets/api/capi/handlers/get_workflow_runs.py
@@ -20,9 +20,10 @@ CAPE_CONF_KEY = "cape"
 
 # Page size when listing runs across all DAGs (Airflow caps page limit at 100).
 DAG_RUNS_PAGE_LIMIT = 100
-# Safety cap on how many recent runs we scan while filtering by owner. Airflow
-# has no server-side filter for a `conf` value, so we page through the most
-# recent runs and match `conf.cape` here.
+# Safety cap on how many recent runs we scan while filtering by owner. Airflow's
+# only server-side filter on `conf` is a substring match (`conf_contains`), so we
+# prefilter with it and re-check exact ownership here; this bounds how deep we
+# page when a substring match happens to be broad.
 MAX_RUNS_SCANNED = 1000
 
 
@@ -127,10 +128,10 @@ def index_handler(event, context):
     only those triggered by the caller (matched on
     `conf.cape.triggering_user_id`).
 
-    TODO: Airflow has no server-side filter for a `conf` value, so ownership
-          filtering is done here after fetching recent runs. For large run
-          volumes this should move to a database-backed ownership index (the
-          CAPE environment DB).
+    TODO: Airflow's only server-side filter on `conf` is a substring match
+          (`conf_contains`), so exact ownership is re-checked here after the
+          prefilter. For large run volumes this should move to a database-backed
+          ownership index (the CAPE environment DB).
 
     :param event: The event object that contains the HTTP request.
     :param context: Context object.
@@ -180,9 +181,9 @@ def index_handler(event, context):
         # Airflow already orders newest-first; sort defensively in case a page
         # boundary or backend quirk perturbs the order.
         matching_runs.sort(
-            key=lambda run: run.get("run_after")
-            or run.get("logical_date")
-            or "",
+            key=lambda run: (
+                run.get("run_after") or run.get("logical_date") or ""
+            ),
             reverse=True,
         )
 

--- a/assets/api/capi/handlers/post_workflow_run.py
+++ b/assets/api/capi/handlers/post_workflow_run.py
@@ -131,9 +131,9 @@ def index_handler(event, context):
 
                 # Surface the triggering user in the run `note` too, so admins
                 # scanning the Airflow runs list can see it without opening conf.
-                user_name = identity.get("triggering_user_name") or identity.get(
-                    "triggering_user_id"
-                )
+                user_name = identity.get(
+                    "triggering_user_name"
+                ) or identity.get("triggering_user_id")
                 if user_name:
                     body["note"] = f"Triggered by {user_name}"
 

--- a/assets/api/capi/handlers/post_workflow_run.py
+++ b/assets/api/capi/handlers/post_workflow_run.py
@@ -9,6 +9,58 @@ import boto3
 from botocore.exceptions import ClientError
 from capepy.aws.utils import bad_param_response, decode_error
 
+# Namespace under the DAG run `conf` where CAPE-owned metadata lives, kept
+# separate from the DAG's own parameters so the two never collide.
+CAPE_CONF_KEY = "cape"
+
+
+def caller_identity_from_event(event):
+    """Read the caller identity injected by the API Gateway authorizer.
+
+    The authorizer resolves the Cognito user and passes it in the request
+    context. We only trust this server-side value for ownership; we never trust
+    identity sent in the request body.
+
+    :param event: The API Gateway proxy event.
+    :return: A dict with any of `triggering_user_id` / `triggering_user_name`.
+    """
+    request_context = event.get("requestContext") or {}
+    authorizer = request_context.get("authorizer") or {}
+
+    identity = {}
+    user_id = authorizer.get("triggering_user_id")
+    if user_id:
+        identity["triggering_user_id"] = str(user_id)
+
+    user_name = authorizer.get("triggering_user_name")
+    if user_name:
+        identity["triggering_user_name"] = str(user_name)
+
+    return identity
+
+
+def apply_cape_identity(conf, identity):
+    """Stamp the resolved caller identity onto a DAG run `conf`.
+
+    Any client-supplied `cape` block is removed first so a caller cannot forge
+    ownership. When no identity is available (e.g. authorizer not yet resolving
+    users) the `cape` block is simply absent.
+
+    :param conf: The DAG run conf dict (the passthrough of the request body).
+    :param identity: The identity dict from `caller_identity_from_event`.
+    :return: The same conf dict, mutated in place and returned for convenience.
+    """
+    if not isinstance(conf, dict):
+        return conf
+
+    # Never allow client-provided CAPE metadata through.
+    conf.pop(CAPE_CONF_KEY, None)
+
+    if identity:
+        conf[CAPE_CONF_KEY] = dict(identity)
+
+    return conf
+
 
 def index_handler(event, context):
     """Handler for the POST to trigger an airflow dag.
@@ -16,6 +68,11 @@ def index_handler(event, context):
     This endpoint is a proxy to the airflow /api/v2/dags/{dag_id}/dagRuns
     endpoint. Done as a lambda instead of direct integration so we can massage
     data as required.
+
+    In addition to forwarding the request body as the DAG run `conf`, this
+    handler stamps the triggering user (resolved by the API Gateway authorizer)
+    into `conf.cape` so ownership is recorded in Airflow state, visible in the
+    Airflow UI, and retrievable via the Airflow API.
 
     :param event: The event object that contains the HTTP request and json
                   data.
@@ -43,11 +100,16 @@ def index_handler(event, context):
                 resp_data, resp_status = bad_param_response(list(req_params))
             else:
 
+                # Stamp the triggering user (from the authorizer context) into
+                # the conf. Client-supplied `cape` metadata is stripped so
+                # ownership cannot be spoofed.
+                identity = caller_identity_from_event(event)
+                dag_params = apply_cape_identity(dag_params, identity)
+
                 # TODO: we can add some additional run params that airflow
                 #       supports:
                 #       - specific run id (probably don't want people using this
                 #         usually if ever)
-                #       - note (freetext string)
                 #       - run_after (if we want to get into scheduling from
                 #         users)
                 #       - there are others like data_interval_[start|end] that
@@ -62,14 +124,24 @@ def index_handler(event, context):
                 now_str = datetime.datetime.now().isoformat()
                 zstr = re.sub(r"\..*$", "Z", now_str)
 
+                body = {
+                    "conf": dag_params,
+                    "logical_date": zstr,  # datetime.datetime.now().isoformat(),
+                }
+
+                # Surface the triggering user in the run `note` too, so admins
+                # scanning the Airflow runs list can see it without opening conf.
+                user_name = identity.get("triggering_user_name") or identity.get(
+                    "triggering_user_id"
+                )
+                if user_name:
+                    body["note"] = f"Triggered by {user_name}"
+
                 request_params = {
                     "Name": env_name,
                     "Path": f"/dags/{dag_id}/dagRuns",
                     "Method": "POST",
-                    "Body": {
-                        "conf": dag_params,
-                        "logical_date": zstr,  # datetime.datetime.now().isoformat(),
-                    },
+                    "Body": body,
                 }
 
                 response = mwaa_client.invoke_rest_api(**request_params)

--- a/assets/api/capi/handlers/post_workflow_run.py
+++ b/assets/api/capi/handlers/post_workflow_run.py
@@ -129,14 +129,6 @@ def index_handler(event, context):
                     "logical_date": zstr,  # datetime.datetime.now().isoformat(),
                 }
 
-                # Surface the triggering user in the run `note` too, so admins
-                # scanning the Airflow runs list can see it without opening conf.
-                user_name = identity.get(
-                    "triggering_user_name"
-                ) or identity.get("triggering_user_id")
-                if user_name:
-                    body["note"] = f"Triggered by {user_name}"
-
                 request_params = {
                     "Name": env_name,
                     "Path": f"/dags/{dag_id}/dagRuns",

--- a/assets/api/capi/handlers/post_workflow_run.py
+++ b/assets/api/capi/handlers/post_workflow_run.py
@@ -72,7 +72,9 @@ def index_handler(event, context):
     In addition to forwarding the request body as the DAG run `conf`, this
     handler stamps the triggering user (resolved by the API Gateway authorizer)
     into `conf.cape` so ownership is recorded in Airflow state, visible in the
-    Airflow UI, and retrievable via the Airflow API.
+    Airflow UI, and retrievable via the Airflow API. A run with no resolvable
+    caller is refused (401) rather than triggered anonymously, matching
+    `GET /workflows/runs`.
 
     :param event: The event object that contains the HTTP request and json
                   data.
@@ -84,6 +86,21 @@ def index_handler(event, context):
     # TODO: add this to capepy
     mwaa_client = boto3.client("mwaa")
 
+    resp_headers = {
+        "Content-Type": "application/json",
+        # TODO: ISSUE #141 CORS bypass. We do not want this long term. When we
+        #       get all the api and web resources on the same domain, this may
+        #       not matter too much. But we may eventually end up needing to
+        #       handle requests from one domain served up by another domain in
+        #       a lambda handler. In that case we'd need to handle CORS, and
+        #       would want to allow configuration of the lambda (via pulumi
+        #       config that turns into env vars) that sets the origins allowed
+        #       for CORS.
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "OPTIONS,GET",
+    }
+
     try:
         req_params = {"dagId"}
 
@@ -92,18 +109,40 @@ def index_handler(event, context):
         if qsp is None:
             resp_data, resp_status = bad_param_response(list(req_params))
         else:
-
             dag_id = qsp.get("dagId")
             dag_params = json.loads(event["body"])
 
             if not dag_id:
                 resp_data, resp_status = bad_param_response(list(req_params))
             else:
-
-                # Stamp the triggering user (from the authorizer context) into
-                # the conf. Client-supplied `cape` metadata is stripped so
-                # ownership cannot be spoofed.
+                # Resolve the triggering user from the authorizer context and
+                # gate on it: a run with no resolvable owner could not be
+                # attributed or listed back to anyone, so refuse it the same
+                # way GET /workflows/runs does rather than trigger anonymously.
+                #
+                # NOTE: the authorizer is still allow-all and does not verify
+                # the JWT signature (see #352), so this currently only requires
+                # a decodable token carrying a `sub`, not a cryptographically
+                # verified identity. Tighten once a verifying Cognito authorizer
+                # lands.
                 identity = caller_identity_from_event(event)
+
+                if not identity.get("triggering_user_id"):
+                    return {
+                        "statusCode": 401,
+                        "headers": resp_headers,
+                        "body": json.dumps(
+                            {
+                                "detail": (
+                                    "Unable to resolve the calling user. A "
+                                    "valid Authorization token is required."
+                                )
+                            }
+                        ),
+                    }
+
+                # Client-supplied `cape` metadata is stripped so ownership
+                # cannot be spoofed.
                 dag_params = apply_cape_identity(dag_params, identity)
 
                 # TODO: we can add some additional run params that airflow
@@ -146,22 +185,7 @@ def index_handler(event, context):
         # the non-200 case
         return {
             "statusCode": resp_status,
-            "headers": {
-                "Content-Type": "application/json",
-                # TODO: ISSUE #141 CORS bypass. We do not want this long term.
-                #       When we get all the api and web resources on the same
-                #       domain, this may not matter too much. But we may
-                #       eventually end up with needing to handle requests from
-                #       one domain served up by another domain in a lambda
-                #       handler. In that case we'd need to be able to handle
-                #       CORS, and would want to look into allowing
-                #       configuration of the lambda (via pulumi config that
-                #       turns into env vars for the lambda) that set the
-                #       origins allowed for CORS.
-                "Access-Control-Allow-Headers": "Content-Type",
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Methods": "OPTIONS,GET",
-            },
+            "headers": resp_headers,
             "body": json.dumps(resp_data),
         }
     except ClientError as err:

--- a/tests/test_workflow_user_attribution.py
+++ b/tests/test_workflow_user_attribution.py
@@ -1,0 +1,292 @@
+"""Unit tests for per-user workflow-run attribution.
+
+These cover the pure, side-effect-free helpers in the capi Lambda handlers and
+the API authorizer:
+
+- the authorizer resolving a Cognito identity from a bearer token,
+- the trigger handler stamping that identity onto the DAG run ``conf`` (and
+  refusing client-supplied identity), and
+- the "my runs" handler resolving the caller and filtering runs by owner.
+
+The handlers are single-file Lambdas (not importable as a package), so they are
+loaded from their source paths.
+"""
+
+import base64
+import importlib.util
+import json
+import os
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_module(name, relpath):
+    path = os.path.join(REPO_ROOT, relpath)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def authorizer():
+    return _load_module(
+        "default_apigw_authorizer",
+        "assets/api/authz/default_apigw_authorizer.py",
+    )
+
+
+@pytest.fixture(scope="module")
+def post_workflow_run():
+    return _load_module(
+        "post_workflow_run",
+        "assets/api/capi/handlers/post_workflow_run.py",
+    )
+
+
+@pytest.fixture(scope="module")
+def get_workflow_runs():
+    return _load_module(
+        "get_workflow_runs",
+        "assets/api/capi/handlers/get_workflow_runs.py",
+    )
+
+
+def _make_jwt(claims):
+    """Build an (unsigned) JWT with the given claims payload."""
+
+    def b64(obj):
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return f"{b64({'alg': 'none'})}.{b64(claims)}.signature"
+
+
+# ---------------------------------------------------------------------------
+# Authorizer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        ({"Authorization": "Bearer abc.def.ghi"}, "abc.def.ghi"),
+        ({"authorization": "bearer abc.def.ghi"}, "abc.def.ghi"),
+        ({"Authorization": "abc.def.ghi"}, "abc.def.ghi"),
+        ({}, None),
+        (None, None),
+        ({"Authorization": ""}, None),
+    ],
+)
+def test_get_bearer_token(authorizer, headers, expected):
+    assert authorizer.get_bearer_token(headers) == expected
+
+
+def test_decode_jwt_claims_valid(authorizer):
+    token = _make_jwt({"sub": "user-123", "email": "a@b.org"})
+    claims = authorizer.decode_jwt_claims(token)
+    assert claims["sub"] == "user-123"
+    assert claims["email"] == "a@b.org"
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["", None, "not-a-jwt", "only.two", 123],
+)
+def test_decode_jwt_claims_invalid(authorizer, token):
+    assert authorizer.decode_jwt_claims(token) == {}
+
+
+def test_identity_context_prefers_sub_and_email(authorizer):
+    ctx = authorizer.identity_context_from_claims(
+        {"sub": "user-123", "email": "a@b.org", "cognito:username": "abc"}
+    )
+    assert ctx == {
+        "triggering_user_id": "user-123",
+        "triggering_user_name": "a@b.org",
+    }
+
+
+def test_identity_context_falls_back_to_username(authorizer):
+    ctx = authorizer.identity_context_from_claims(
+        {"sub": "user-123", "cognito:username": "abc"}
+    )
+    assert ctx == {
+        "triggering_user_id": "user-123",
+        "triggering_user_name": "abc",
+    }
+
+
+def test_identity_context_empty_when_no_claims(authorizer):
+    assert authorizer.identity_context_from_claims({}) == {}
+
+
+def test_identity_context_from_headers_end_to_end(authorizer):
+    token = _make_jwt({"sub": "u1", "email": "u1@x.org"})
+    ctx = authorizer.identity_context_from_headers(
+        {"Authorization": f"Bearer {token}"}
+    )
+    assert ctx == {
+        "triggering_user_id": "u1",
+        "triggering_user_name": "u1@x.org",
+    }
+
+
+def test_handler_puts_identity_in_policy_context(authorizer):
+    token = _make_jwt({"sub": "u1", "email": "u1@x.org"})
+    resp = authorizer.lambda_handler(
+        {"headers": {"Authorization": f"Bearer {token}"}}, None
+    )
+    assert resp["principalId"] == "u1"
+    assert resp["context"]["triggering_user_id"] == "u1"
+    assert resp["context"]["triggering_user_name"] == "u1@x.org"
+    assert resp["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+
+
+def test_handler_allows_anonymous_with_empty_context(authorizer):
+    resp = authorizer.lambda_handler({"headers": {}}, None)
+    assert resp["principalId"] == "unknown"
+    assert resp["context"] == {}
+    assert resp["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+
+
+# ---------------------------------------------------------------------------
+# Trigger handler: conf.cape stamping
+# ---------------------------------------------------------------------------
+
+
+def test_caller_identity_from_event(post_workflow_run):
+    event = {
+        "requestContext": {
+            "authorizer": {
+                "triggering_user_id": "u1",
+                "triggering_user_name": "u1@x.org",
+            }
+        }
+    }
+    assert post_workflow_run.caller_identity_from_event(event) == {
+        "triggering_user_id": "u1",
+        "triggering_user_name": "u1@x.org",
+    }
+
+
+def test_caller_identity_from_event_missing(post_workflow_run):
+    assert post_workflow_run.caller_identity_from_event({}) == {}
+
+
+def test_apply_cape_identity_sets_block(post_workflow_run):
+    conf = {"pipelineConfigs": [{"pipelineId": "p1"}]}
+    identity = {"triggering_user_id": "u1", "triggering_user_name": "u1@x.org"}
+    result = post_workflow_run.apply_cape_identity(conf, identity)
+    assert result["cape"] == identity
+    # DAG params are preserved.
+    assert result["pipelineConfigs"] == [{"pipelineId": "p1"}]
+
+
+def test_apply_cape_identity_strips_client_supplied(post_workflow_run):
+    # A caller trying to forge ownership must not succeed.
+    conf = {"cape": {"triggering_user_id": "attacker"}, "pipelineConfigs": []}
+    identity = {"triggering_user_id": "u1"}
+    result = post_workflow_run.apply_cape_identity(conf, identity)
+    assert result["cape"] == {"triggering_user_id": "u1"}
+
+
+def test_apply_cape_identity_removes_forged_when_no_identity(post_workflow_run):
+    conf = {"cape": {"triggering_user_id": "attacker"}, "pipelineConfigs": []}
+    result = post_workflow_run.apply_cape_identity(conf, {})
+    assert "cape" not in result
+
+
+# ---------------------------------------------------------------------------
+# List handler: caller resolution + ownership filtering
+# ---------------------------------------------------------------------------
+
+
+def test_caller_user_id_from_authorizer(get_workflow_runs):
+    event = {"requestContext": {"authorizer": {"triggering_user_id": "u1"}}}
+    assert get_workflow_runs.caller_user_id(event) == "u1"
+
+
+def test_caller_user_id_qsp_fallback(get_workflow_runs):
+    event = {"queryStringParameters": {"userId": "u2"}}
+    assert get_workflow_runs.caller_user_id(event) == "u2"
+
+
+def test_caller_user_id_none(get_workflow_runs):
+    assert get_workflow_runs.caller_user_id({}) is None
+
+
+@pytest.mark.parametrize(
+    "run,expected",
+    [
+        ({"conf": {"cape": {"triggering_user_id": "u1"}}}, True),
+        ({"conf": {"cape": {"triggering_user_id": "other"}}}, False),
+        ({"conf": {"cape": {}}}, False),
+        ({"conf": {}}, False),
+        ({}, False),
+        ({"conf": {"cape": "not-a-dict"}}, False),
+    ],
+)
+def test_run_belongs_to_user(get_workflow_runs, run, expected):
+    assert get_workflow_runs.run_belongs_to_user(run, "u1") is expected
+
+
+def test_filter_runs_for_user(get_workflow_runs):
+    runs = [
+        {"dag_run_id": "a", "conf": {"cape": {"triggering_user_id": "u1"}}},
+        {"dag_run_id": "b", "conf": {"cape": {"triggering_user_id": "u2"}}},
+        {"dag_run_id": "c", "conf": {"cape": {"triggering_user_id": "u1"}}},
+        {"dag_run_id": "d", "conf": {}},
+    ]
+    result = get_workflow_runs.filter_runs_for_user(runs, "u1")
+    assert [r["dag_run_id"] for r in result] == ["a", "c"]
+
+
+def test_filter_runs_for_user_empty(get_workflow_runs):
+    assert get_workflow_runs.filter_runs_for_user(None, "u1") == []
+
+
+class _FakeMwaaClient:
+    """Minimal MWAA client double that serves paginated dagRuns responses."""
+
+    def __init__(self, total, page_limit):
+        self._total = total
+        self._page_limit = page_limit
+        self.calls = []
+
+    def invoke_rest_api(self, **params):
+        self.calls.append(params)
+        offset = params["QueryParameters"]["offset"]
+        page = [
+            {"dag_run_id": f"run-{i}"}
+            for i in range(offset, min(offset + self._page_limit, self._total))
+        ]
+        return {
+            "RestApiResponse": {"dag_runs": page, "total_entries": self._total},
+            "RestApiStatusCode": 200,
+        }
+
+
+def test_list_all_dag_runs_paginates(get_workflow_runs):
+    total = get_workflow_runs.DAG_RUNS_PAGE_LIMIT * 2 + 5
+    client = _FakeMwaaClient(total, get_workflow_runs.DAG_RUNS_PAGE_LIMIT)
+
+    runs = get_workflow_runs._list_all_dag_runs(client, "env")
+
+    assert len(runs) == total
+    # One request per page: ceil(total / page_limit).
+    assert len(client.calls) == 3
+    # Every request hits the cross-DAG list endpoint via GET.
+    assert all(c["Path"] == "/dags/~/dagRuns/list" for c in client.calls)
+    assert all(c["Method"] == "GET" for c in client.calls)
+
+
+def test_list_all_dag_runs_stops_on_empty_page(get_workflow_runs):
+    client = _FakeMwaaClient(0, get_workflow_runs.DAG_RUNS_PAGE_LIMIT)
+
+    runs = get_workflow_runs._list_all_dag_runs(client, "env")
+
+    assert runs == []
+    assert len(client.calls) == 1

--- a/tests/test_workflow_user_attribution.py
+++ b/tests/test_workflow_user_attribution.py
@@ -25,6 +25,8 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 def _load_module(name, relpath):
     path = os.path.join(REPO_ROOT, relpath)
     spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load {name} from {path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_workflow_user_attribution.py
+++ b/tests/test_workflow_user_attribution.py
@@ -201,6 +201,62 @@ def test_apply_cape_identity_removes_forged_when_no_identity(post_workflow_run):
     assert "cape" not in result
 
 
+def test_index_handler_refuses_without_identity(post_workflow_run, monkeypatch):
+    # The trigger path must refuse to run a DAG for an unresolved caller
+    # (matching GET /workflows/runs) and must not reach MWAA.
+    class _NoCallMwaa:
+        def invoke_rest_api(self, **_):
+            raise AssertionError("MWAA must not be called without an identity")
+
+    monkeypatch.setattr(
+        post_workflow_run.boto3, "client", lambda *a, **k: _NoCallMwaa()
+    )
+
+    event = {
+        "queryStringParameters": {"dagId": "d1"},
+        "body": json.dumps({"pipelineConfigs": []}),
+        "requestContext": {"authorizer": {}},
+    }
+    resp = post_workflow_run.index_handler(event, None)
+    assert resp["statusCode"] == 401
+
+
+def test_index_handler_stamps_identity_and_triggers(
+    post_workflow_run, monkeypatch
+):
+    # With a resolvable caller the run is stamped and forwarded to MWAA.
+    captured = {}
+
+    class _FakeMwaa:
+        def invoke_rest_api(self, **params):
+            captured.update(params)
+            return {
+                "RestApiResponse": {"dag_run_id": "r1"},
+                "RestApiStatusCode": 200,
+            }
+
+    monkeypatch.setattr(
+        post_workflow_run.boto3, "client", lambda *a, **k: _FakeMwaa()
+    )
+
+    event = {
+        "queryStringParameters": {"dagId": "d1"},
+        "body": json.dumps({"pipelineConfigs": []}),
+        "requestContext": {
+            "authorizer": {
+                "triggering_user_id": "u1",
+                "triggering_user_name": "u1@x.org",
+            }
+        },
+    }
+    resp = post_workflow_run.index_handler(event, None)
+    assert resp["statusCode"] == 200
+    assert captured["Body"]["conf"]["cape"] == {
+        "triggering_user_id": "u1",
+        "triggering_user_name": "u1@x.org",
+    }
+
+
 # ---------------------------------------------------------------------------
 # List handler: caller resolution + ownership filtering
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow_user_attribution.py
+++ b/tests/test_workflow_user_attribution.py
@@ -211,9 +211,11 @@ def test_caller_user_id_from_authorizer(get_workflow_runs):
     assert get_workflow_runs.caller_user_id(event) == "u1"
 
 
-def test_caller_user_id_qsp_fallback(get_workflow_runs):
+def test_caller_user_id_ignores_query_string(get_workflow_runs):
+    # A `userId` query parameter must NOT be trusted: identity comes only from
+    # the authorizer context, so a caller cannot list another user's runs.
     event = {"queryStringParameters": {"userId": "u2"}}
-    assert get_workflow_runs.caller_user_id(event) == "u2"
+    assert get_workflow_runs.caller_user_id(event) is None
 
 
 def test_caller_user_id_none(get_workflow_runs):

--- a/tests/test_workflow_user_attribution.py
+++ b/tests/test_workflow_user_attribution.py
@@ -281,7 +281,7 @@ def test_list_all_dag_runs_paginates(get_workflow_runs):
     # One request per page: ceil(total / page_limit).
     assert len(client.calls) == 3
     # Every request hits the cross-DAG list endpoint via GET.
-    assert all(c["Path"] == "/dags/~/dagRuns/list" for c in client.calls)
+    assert all(c["Path"] == "/dags/~/dagRuns" for c in client.calls)
     assert all(c["Method"] == "GET" for c in client.calls)
 
 


### PR DESCRIPTION
Attributes each Airflow DAG run to the Cognito user who triggered it and adds a per-user run listing, without a database dependency.

**API**

- Resolve the caller from the Cognito bearer token in the authorizer and stamp `{ triggering_user_id, triggering_user_name }` into the DAG run `conf.cape` on trigger (`post_workflow_run.py`). Any client-supplied `conf.cape` is stripped first (anti-spoofing).
- Add `GET /workflows/runs` (`get_workflow_runs.py`): lists recent runs across all DAGs via Airflow 3's cross-DAG endpoint `/dags/~/dagRuns`, using the server-side `conf_contains` substring prefilter (ordered by `-run_after`, scan-capped), then re-checks `conf.cape.triggering_user_id` exactly in the proxy so a coincidental substring match cannot leak another user's run.
- Wire the endpoint into `capi-openapi-301.yaml.j2` and register the handler in `Pulumi.cape-cod-dev.yaml` / `Pulumi.cape-cod-public.yaml`.

**Auth note**

- The authorizer decodes the token but does not yet verify the signature. Migrating to a native API Gateway Cognito User Pools authorizer is tracked in #352.

**Docs**

- llm-wiki analysis/entity pages document the attribution design, the MWAA single-IAM-principal constraint, and why the real user cannot authenticate into MWAA Airflow.
- Document `pulumi preview --diff` as a required deployment-preparation review step (AGENTS.md plus the testing wiki page), including the known benign recurring `cape-cod-dev` drift.

**Related**

- Frontend counterpart: cape-ph/cape-frontend#31.
- Refs #352 (authorizer hardening), Refs cape-ph/cape-frontend#30 (future DB-backed listing).

**Validation**

- `pytest tests/test_workflow_user_attribution.py` -> 36 passed; black, isort, and pyright clean.
- `pulumi preview --diff -s cape-cod-dev` reviewed: the feature changes match scope (authorizer and post-handler code, new getdagruns lambda plus its invoke permission, spec route, and API redeploy); the rest of the diff is known benign drift.
