### PR TITLE
feat(seqauto): add split-read outputs, notify queue, and per-upload manifest

### DIFF
--- a/.llm-wiki/wiki/sources/etl-notifier-ddb-table-name-mismatch.md
+++ b/.llm-wiki/wiki/sources/etl-notifier-ddb-table-name-mismatch.md
@@ -1,0 +1,44 @@
+---
+type: source
+title: "ETL never triggers: notifier ETL_ATTRS_DDB_TABLE env uses logical name, misses -DDBT physical suffix"
+slug: etl-notifier-ddb-table-name-mismatch
+status: insight
+created: 2026-08-05
+updated: 2026-08-05
+category: bugfix
+---
+# ETL never triggers: notifier ETL_ATTRS_DDB_TABLE env uses logical name, misses -DDBT physical suffix
+Definitive root cause of "S3 upload to unprocessed/ never fires the ETL" for seqauto (and every tributary using this path).
+
+**Symptom:** notifier Lambda `ccd-dlh-T-seqauto-lmbdtrgfnct-*` is invoked on each `s3:ObjectCreated:*` but crashes on every invocation with:
+```
+AccessDeniedException ... not authorized to perform: dynamodb:DescribeTable
+  on resource: table/ccd-dlh-ETLAttrs
+  File ".../capepy/aws/dynamodb.py", line 30, in __init__  ->  self.table.load()
+  File "/var/task/index.py", line 69  ->  ddb_table = EtlTable()
+```
+It dies at `EtlTable()` construction (capepy's `Table.__init__` unconditionally calls `self.table.load()`, a DescribeTable) before ever reading ETL attrs or sending to the queue.
+
+**Root cause = DynamoDB table-name mismatch:**
+- Notifier env `ETL_ATTRS_DDB_TABLE = ccd-dlh-ETLAttrs` (the logical/component name).
+- Real table AND the role's IAM grant = `ccd-dlh-ETLAttrs-DDBT` (only that table exists).
+- capepy `EtlTable()` reads `os.getenv("ETL_ATTRS_DDB_TABLE")` -> queries `ccd-dlh-ETLAttrs`, which is neither the real table nor in the role allow-list -> AccessDenied on DescribeTable.
+
+**Where the bug is (`capeinfra/`, NOT the split-reads branch):**
+- `capeinfra/resources/database.py`: `DynamoTable.__init__` sets `self.name = name` but creates the physical table as `aws.dynamodb.Table(f"{self.name}-ddbt", name=f"{self.name}-DDBT", ...)`, exposed as `self.ddb_table.name`. The `-DDBT` physical suffix landed in commit 7b41e705 (Pihera, 2025-12-09).
+- `capeinfra/datalake/datalake.py:593`: notifier env is `"ETL_ATTRS_DDB_TABLE": etl_attrs_ddb_table.name` (logical), while the IAM policy correctly uses `etl_attrs_ddb_table.ddb_table.arn` (physical `-DDBT`). That divergence is the bug.
+
+**Fix (one line):** `datalake.py:593` -> `"ETL_ATTRS_DDB_TABLE": etl_attrs_ddb_table.ddb_table.name`. Requires a deploy. Since it is shared infra affecting ALL tributaries (genomics, hai, seqauto) since 2025-12-09, it is arguably its own hotfix/PR rather than folded into the seqauto split-reads branch. The read policy already correctly includes DescribeTable/GetItem/Query/Scan on the physical ARN, so no IAM change is needed.
+
+**Fast test-unblock (mutating, gated):** `aws lambda update-function-configuration --function-name ccd-dlh-T-seqauto-lmbdtrgfnct-* --environment "Variables={ETL_ATTRS_DDB_TABLE=ccd-dlh-ETLAttrs-DDBT,...}"` temporarily repoints the running Lambda so Phase 1 can be tested immediately. Caveat: out-of-band from Pulumi; a later `pulumi up` reverts it and it shows as preview drift.
+
+**Confirmed-healthy (rules out other causes):** object landed at `unprocessed/plainreads-fastq.tar.gz` in the real input-raw bucket `ccd-dlh-t-seqauto-input-raw-vbkt-s3-b8fded5`; bucket notification is wired to the notifier; the DDB row in `ccd-dlh-ETLAttrs-DDBT` is correct (`bucket_name=...input-raw..., prefix=unprocessed, suffixes=[gz,tar], sink=...input-clean..., etl_job=ccd-dlh-T-seqauto-ETL-seqreadarch-003945d`). Once the table name is fixed, `.gz` matches and the ETL will enqueue.
+
+**Naming gotcha:** the string `ccd-dlh-T-seqauto-ETL-seqreadarch-003945d` (which looked like a bucket) is actually the `etl_job` value / Glue job resource name stored in the DDB row - not an S3 bucket. S3 bucket names are lowercase-only, so the uppercase T/ETL are a tell it is a Pulumi resource name.
+
+Related: [[sources/obs-2026-08-04-ddb-row-verified-correct-tar-gz-unprocessed-trigger-failure-]], [[sources/obs-2026-08-04-direct-s3-dump-to-unprocessed-did-not-fire-the-etl-suspected]].
+*Category: bugfix*
+---
+*Captured: 2026-08-05*
+## Related
+_Add links to related pages._

--- a/.llm-wiki/wiki/sources/etl-same-bucket-src-sink-notification-loop.md
+++ b/.llm-wiki/wiki/sources/etl-same-bucket-src-sink-notification-loop.md
@@ -1,0 +1,68 @@
+---
+type: source
+title: "Known issue: same-bucket ETL src=sink can loop via the notifier prefix walk"
+slug: etl-same-bucket-src-sink-notification-loop
+status: insight
+created: 2026-08-04
+updated: 2026-08-04
+category: architecture
+---
+# Known issue: same-bucket ETL src=sink can loop via the notifier prefix walk
+## Known issue (cape-cod datalake ETL)
+
+The datalake ETL config places no directional constraint on a job's `src` and
+`sink`. Bucket names in `pipelines.data.etl[]` are just config keys resolved via
+`self.buckets[cfg["src"]]` / `self.buckets[cfg["sink"]]` in
+`Tributary.configure_etl` (`capeinfra/datalake/datalake.py`). So all of these
+are structurally valid and wireable today:
+
+- clean bucket as `src`, raw bucket as `sink` (e.g. `src: input-clean`,
+  `sink: result-raw`)
+- the SAME bucket as both `src` and `sink` (the Glue role just gets READ+WRITE
+  on that one bucket and `--SINK_BUCKET_NAME` points at it)
+
+What `src`/`sink` actually wire: `src` = S3 trigger attach (`self.sources`) +
+Glue role READ grant + the `ETLAttrs` DDB lookup key `(bucket, prefix)`; `sink`
+= Glue role WRITE grant + the `--SINK_BUCKET_NAME` job argument the script reads.
+
+### The loop gotcha
+
+Same-bucket `src=sink` is loop-prone, and there is NO infra-level guard - it is
+pure config discipline. The trigger notifier
+(`assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py`) matches like
+this: it takes the new object's key, strips the filename to a directory prefix,
+then walks that prefix UPWARD (`prefix.rpartition("/")` in a loop), calling
+`EtlTable.get_etls(bucket, prefix)` at each ancestor level. `ETLAttrs` is keyed
+`hash_key=bucket_name`, `range_key=prefix`, so each lookup is an EXACT match on a
+prefix segment. An object re-triggers the ETL iff some ancestor directory of its
+key exactly equals a configured trigger prefix for that bucket AND its suffix is
+in that job's `suffixes` list.
+
+Consequence: if an ETL writes its output back into the same bucket under (or
+nested beneath) its own trigger prefix with a matching suffix, the output
+re-triggers the job -> infinite loop.
+
+### Loop-safety rule
+
+- Write output to a prefix that is neither the trigger prefix nor nested under
+  it - a disjoint sibling prefix. Trigger prefix `incoming`, output
+  `processed/out.csv` is safe (walk hits `processed`, which matches no configured
+  prefix). Output `incoming/done/out.csv` LOOPS (walk reaches `incoming`).
+- Suffix is a secondary, more fragile lever: output under the trigger prefix but
+  with a suffix outside the trigger's set is ignored, but adding that suffix
+  later silently re-arms the loop.
+
+S3 events don't cheaply carry the writing principal, so the notifier can't tell
+"a user dropped this" from "our own Glue job wrote this." A by-construction fix
+would need something explicit (an excluded output prefix in the filter, or the
+notifier ignoring the ETL's own output path). Not built - no one has requested
+same-bucket ETL; this was captured while probing what the model permits.
+
+Related: [[sources/obs-2026-08-04-etl-sinks-never-get-s3-notifications-today-notify-type-union]]
+(ETL sinks get no notification today; the notify consumer type + union-iteration
+assembler is what makes sink-side / clean-bucket reactions expressible).
+*Category: architecture*
+---
+*Captured: 2026-08-04*
+## Related
+_Add links to related pages._

--- a/.llm-wiki/wiki/sources/notify-queue-phase2-datalake-wiring-capeconfig-list-gotcha.md
+++ b/.llm-wiki/wiki/sources/notify-queue-phase2-datalake-wiring-capeconfig-list-gotcha.md
@@ -1,0 +1,27 @@
+---
+type: source
+title: "Notify-queue Phase 2b: datalake.py wiring + CapeConfig list-item gotcha"
+slug: notify-queue-phase2-datalake-wiring-capeconfig-list-gotcha
+status: insight
+created: 2026-08-05
+updated: 2026-08-05
+category: architecture
+---
+# Notify-queue Phase 2b: datalake.py wiring + CapeConfig list-item gotcha
+Completed the second half of the config-driven S3->SQS notification feature (Phase 2b) building on the already-landed queue.py/lambda pure-function work from [[sources/obs-2026-08-05-phase-2-notify-queue-feature-added-to-sqsqueue-and-s3-notifi]].
+
+capeinfra/datalake/datalake.py (Tributary class):
+- __init__ now parses optional `self.notify_cfgs` from `pipelines.data.notify` config and creates `self.notify_queue` (SQSQueue named f"{self.name}-ntfq") only when notify config is present. IMPORTANT GOTCHA: CapeConfig.get() (capepulumi.py) only wraps Mapping results in CapeConfig - list results come back as plain dicts. Calling `.get("key", default=...)` (keyword form) on those plain dict list items raises `TypeError: dict.get() takes no keyword arguments` at runtime (only caught by actually running pytest against the real dev stack config, not by static analysis). Fix: wrap each list entry explicitly, e.g. `self.notify_cfgs = [CapeConfig(ncfg) for ncfg in self.config.get("pipelines", "data", "notify", default=[])]`. The existing configure_etl() sidesteps this because it re-wraps `cfg` inside EtlJob's own CapeComponentResource.__init__ (config=cfg kwarg), so `job.config.get(...)` works - but any NEW code iterating a raw config list directly needs the same explicit CapeConfig() wrap per item.
+- configure_src_bucket_notifications extended additively: role gets a conditional notify-queue put_msg statement, Lambda env gets conditional NOTIFY_QUEUE_NAME/TRIBUTARY_NAME/NOTIFY_RULES (built via Output.all(**{src: bucket.id}) keyed by physical bucket name, since that's what S3 events carry), and the permission/notification loop iterates `self.sources | set(notify_srcs)` so notify-only buckets (e.g. input-clean with no ETL) also get wired. When notify config is absent, notify_srcs=[] so this is byte-identical to the pre-feature code (verified: existing hai/genomics tributaries get zero behavioral diff).
+- Preserved exact Pulumi logical resource names throughout (role, lambda, per-source permission/notification, existing ETL queue) to avoid forcing replacement of the shared deployed notifier.
+
+Pulumi.cape-cod-dev.yaml: added `notify: [{name: split-reads, src: input-clean, prefix: sequencing-reads-split, message_retention_seconds: 43200}]` under seqauto's pipelines.data, plus schema doc comments and a WARNING about self-triggering loops (watching a prefix the same pipeline writes into).
+
+tests/test_notifier_lambda.py (new): unit tests for match_notify_rules/build_notify_message loaded via importlib.util.spec_from_file_location (matches tests/test_workflow_user_attribution.py convention for single-file Lambdas), with AWS_DEFAULT_REGION set before import since the module calls boto3.client("sqs") at import time.
+
+Known pre-existing test failures unrelated to this work (confirmed via git stash before/after): tests/test_capemeta.py::test_asset_bucket and tests/test_datalake.py::test_catalog both fail on a real unmocked `boto3` S3 GetObject NoSuchBucket during catalog bucket construction - needs AWS creds/network, not fixable without touching unrelated code. This also means the mock_datalake fixture (which builds a full DatalakeHouse from the real dev stack config) can never be used to assert notify-wiring identity without first fixing that gap; left a NOTE comment in tests/test_datalake.py explaining this and pointing at `pulumi preview` for identity verification instead of forcing a fragile mock-based test.
+*Category: architecture*
+---
+*Captured: 2026-08-05*
+## Related
+_Add links to related pages._

--- a/.llm-wiki/wiki/sources/obs-2026-08-03-tributary-notification-plumbing-delivery-model-decision-pend.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-03-tributary-notification-plumbing-delivery-model-decision-pend.md
@@ -1,0 +1,27 @@
+---
+type: source
+title: "Observation: Tributary notification plumbing - delivery-model decision pending EventBridge cost tradeoff"
+slug: obs-2026-08-03-tributary-notification-plumbing-delivery-model-decision-pend
+status: observation
+created: 2026-08-03
+updated: 2026-08-03
+relevance: high
+observed_at: 2026-08-03T20:22:57.269Z
+tags: ["datalake", "tributary", "sqs", "notifications", "eventbridge", "planning", "seqauto"]
+source_context: "Multi-day planning session for config-driven tributary queue/notification plumbing (seqauto pilot)"
+---
+# ⭐ Observation: Tributary notification plumbing - delivery-model decision pending EventBridge cost tradeoff
+Planning (PLAN.md, plan mode) a reusable, config-driven S3-notification + SQS queue capability on Tributary (capeinfra/datalake/datalake.py), piloted on the seqauto input-clean bucket. Goal: any of a tributary's 4 buckets (input-raw/clean, result-raw/clean) can raise S3 ObjectCreated notifications to a queue by config alone, present-if-configured. Consumer is an external, non-public app (containers watching a filesystem, pull model) that must NOT be named in any committed file; cape-cod delivers only notification + queue + consumer IAM.
+
+Locked: one notification pattern only; DLQ/redrive out of scope; filter at enqueue (not a scheduled cleaner) as primary defense; queue stays FIFO if mediator Lambda wins.
+
+Open, resume here next session: delivery model. Front-runner is a generic config-driven mediator Lambda (S3 -> notifier Lambda that filters + shapes an app-agnostic message -> FIFO queue -> consumer), chosen because use cases need Lambda-level logic beyond S3 native filters (S3 allows only one prefix/one suffix per rule, and only one BucketNotification config per bucket). Live alternative: S3 -> EventBridge -> SQS with event-pattern filtering + input transformer, no Lambda. Deciding axis is COST: runtime/operating cost AND cost-to-change already-deployed infra.
+
+Also open: queue topology (dedicated per notification vs reuse per-tributary src_data_queue), whether to migrate the existing ETL notifier onto the one pattern (recommend: allow later, don't force now), and consumer credential delivery. Verification is pytest + pulumi preview --diff -s cape-cod-dev; never pulumi up; never hand-edit Pulumi.cape-cod-public.yaml.
+*Relevance: high*
+
+*Context: Multi-day planning session for config-driven tributary queue/notification plumbing (seqauto pilot)*
+
+*Tags: datalake tributary sqs notifications eventbridge planning seqauto*
+---
+*Observed: 2026-08-03T20:22:57.269Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-consumer-result-write-back-target-deferred-output-is-bactopi.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-consumer-result-write-back-target-deferred-output-is-bactopi.md
@@ -1,0 +1,23 @@
+---
+type: source
+title: "Observation: Consumer result write-back target deferred; output is bactopia-independent"
+slug: obs-2026-08-04-consumer-result-write-back-target-deferred-output-is-bactopi
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: medium
+observed_at: 2026-08-04T19:07:39.126Z
+tags: ["seqauto", "result-raw", "result-clean", "bactopia", "deferred", "instance-profile"]
+source_context: "Grill-me on the tributary notification plumbing design (seqauto pilot)"
+---
+# 🔍 Observation: Consumer result write-back target deferred; output is bactopia-independent
+Grill outcome. The external consumer's write-back to a seqauto result bucket is deliberately NOT resolved in the notification-plumbing branch. Its output is a JSON file, is INDEPENDENT of bactopia, and must NOT trigger the existing result-raw bactopia ETLs (bactopia-results: prefix pipeline-output/bactopia-runs, suffixes tsv/yml; bactopia-samples: prefix pipeline-output, suffixes tsv/txt). bactopia runs on the results of the current ETL; the new consumer runs in parallel.
+
+OPEN / deferred to the instance-profile (VM) branch: the write target is undecided - originally result-raw to preserve a later-transform option, but result-clean is now also on the table since the clean-bucket notify mechanism exists; it depends on consumer behavior not yet known (single live file vs write-once). If result-clean, decide whether its crawler (prefix `result`, no excludes today) should skip the JSON. None of this blocks the notification-plumbing branch, which only creates + exposes the notify queue and relies on the consumer's read of input-clean.
+*Relevance: medium*
+
+*Context: Grill-me on the tributary notification plumbing design (seqauto pilot)*
+
+*Tags: seqauto result-raw result-clean bactopia deferred instance-profile*
+---
+*Observed: 2026-08-04T19:07:39.126Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-ddb-row-verified-correct-tar-gz-unprocessed-trigger-failure-.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-ddb-row-verified-correct-tar-gz-unprocessed-trigger-failure-.md
@@ -1,0 +1,23 @@
+---
+type: source
+title: "Observation: DDB row verified correct [tar,gz]/unprocessed - trigger failure narrowed to S3 notification wiring or invocation"
+slug: obs-2026-08-04-ddb-row-verified-correct-tar-gz-unprocessed-trigger-failure-
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T20:51:40.699Z
+tags: ["seqauto", "etl", "s3-notification", "troubleshooting", "deploy", "glue"]
+source_context: "Phase 1 testing: DDB verified correct, diagnosis narrowed to notification wiring / invocation"
+---
+# ⭐ Observation: DDB row verified correct [tar,gz]/unprocessed - trigger failure narrowed to S3 notification wiring or invocation
+Follow-up to the direct-dump-didn't-fire issue: user verified the deployed ETLAttrs DynamoDB row is correct - prefix `unprocessed`, suffixes `[tar, gz]`. This eliminates the "stale DDB missing gz" theory. Combined with the repo config being correct (no S3-level filter, notifier suffix `.tar.gz` -> `gz` which is in the row), the notifier WOULD enqueue if it were invoked.
+
+So the diagnosis narrows to everything OTHER than config/DDB. Highest-priority checks for next session, in order: (1) Does the input-raw bucket actually have the `BucketNotification` wired to the notifier Lambda? `aws s3api get-bucket-notification-configuration --bucket <seqauto-input-raw>` - empty/missing = drift or never deployed, the leading hypothesis now. (2) Notifier `*-lmbdtrgfnct` CloudWatch logs around upload time - no invocation confirms the notification isn't firing; an invocation that logs "ignored"/exception points elsewhere. (3) Confirm objects landed directly under `unprocessed/` in the real src bucket. (4) Downstream: ETL FIFO queue metrics, SQS-trigger Lambda logs, Glue run history. User will deploy and retest tomorrow AM; a deploy would re-assert the bucket notification if it had drifted.
+*Relevance: high*
+
+*Context: Phase 1 testing: DDB verified correct, diagnosis narrowed to notification wiring / invocation*
+
+*Tags: seqauto etl s3-notification troubleshooting deploy glue*
+---
+*Observed: 2026-08-04T20:51:40.699Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-delivery-model-locked-extend-mediator-lambda-pattern-eventbr.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-delivery-model-locked-extend-mediator-lambda-pattern-eventbr.md
@@ -1,0 +1,27 @@
+---
+type: source
+title: "Observation: Delivery model locked: extend mediator-Lambda pattern, EventBridge deferred to future infra pass"
+slug: obs-2026-08-04-delivery-model-locked-extend-mediator-lambda-pattern-eventbr
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T15:10:31.261Z
+tags: ["datalake", "tributary", "sqs", "notifications", "eventbridge", "planning", "seqauto", "delivery-model"]
+source_context: "Multi-day planning: config-driven tributary S3-notification + queue plumbing (seqauto pilot)"
+---
+# ⭐ Observation: Delivery model locked: extend mediator-Lambda pattern, EventBridge deferred to future infra pass
+Delivery-model decision LOCKED for the tributary notification plumbing branch (PLAN.md): extend the existing mediator-Lambda pattern to all four tributary buckets, config-driven. EventBridge was evaluated and deferred to a future infra pass. Rationale: for this branch's need (triggered functions on clean buckets), EventBridge's only genuine ease-of-implementation win is multiple independent consumers on ONE bucket via S3 event fan-out, and this branch does not need that - the seqauto pilot targets input-clean, which has no existing notifications (it is an ETL sink, not a source), so there is exactly one target and no fan-out. Keeping the mediator Lambda preserves the app-owned message contract and in-code filtering. Queue stays FIFO.
+
+ETL path stays untouched this branch (no forced EventBridge migration). Reusable-design constraint that remains: notifications must be assembled PER BUCKET into a single aws.s3.BucketNotification (a second resource clobbers the first), so a bucket that is both an ETL source and a notification target needs aggregated targets; seqauto pilot does not hit this. Also noted: current ETL notifier uses a single static FIFO MessageGroupId so each tributary queue processes serially today.
+
+Parked for a future infra-simplification pass (no production system yet, only integration env): EventBridge as multi-consumer eventing layer, ETL queue consolidation (one shared queue with MessageGroupId per tributary/source bucket), general cost review.
+
+Still open for this branch: sync-queue topology (decided by whether one external consumer serves all tributaries or one per tributary) and consumer credential delivery.
+*Relevance: high*
+
+*Context: Multi-day planning: config-driven tributary S3-notification + queue plumbing (seqauto pilot)*
+
+*Tags: datalake tributary sqs notifications eventbridge planning seqauto delivery-model*
+---
+*Observed: 2026-08-04T15:10:31.261Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-direct-s3-dump-to-unprocessed-did-not-fire-the-etl-suspected.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-direct-s3-dump-to-unprocessed-did-not-fire-the-etl-suspected.md
@@ -1,0 +1,25 @@
+---
+type: source
+title: "Observation: Direct S3 dump to unprocessed/ did not fire the ETL - suspected deploy/runtime, config is correct"
+slug: obs-2026-08-04-direct-s3-dump-to-unprocessed-did-not-fire-the-etl-suspected
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T20:49:24.976Z
+tags: ["seqauto", "etl", "s3-notification", "troubleshooting", "deploy", "dynamodb", "glue"]
+source_context: "Phase 1 testing: direct S3 dump to unprocessed/ did not trigger the ETL"
+---
+# ⭐ Observation: Direct S3 dump to unprocessed/ did not fire the ETL - suspected deploy/runtime, config is correct
+User dumped the two test `.tar.gz` archives directly into the seqauto input-raw bucket's `unprocessed/` prefix (bypassing the front end) WITHOUT deploying the branch, expecting the already-deployed old ETL to fire. Nothing happened.
+
+Repo analysis says the config is correct for these files: the input-raw `BucketNotification` uses `events=["s3:ObjectCreated:*"]` with no S3-level prefix/suffix filter, the notifier computes suffix as the final dot-segment (`.tar.gz` -> `"gz"`), and `seqreadarch` has `prefix: unprocessed`, `suffixes: [gz, tar]`, so `"gz"` matches. This branch touches neither the trigger path nor the ETL config (only the crawler `excludes` line + ETL output), and the `gz` suffix has been committed since 2025-08. So the split-reads changes are NOT what's blocking a trigger. Conclusion: this is a deployed-state/runtime problem, not config logic.
+
+Diagnostic order for next session (agent can't hit AWS here - invalid token): (1) `aws s3api get-bucket-notification-configuration --bucket <seqauto-input-raw>` - expect a Lambda config `s3:ObjectCreated:*` -> notifier `*-lmbdtrgfnct`; empty = drift / not deployed, which alone explains it. (2) notifier CloudWatch logs around upload time - invoked? "ignored due to not passing filter criteria"? exception? (3) ETLAttrs DDB row for (input-raw bucket name, `unprocessed`) with suffixes including `gz` - a stale deploy could omit `gz` even though the YAML has it. (4) confirm objects are directly under `unprocessed/` in the real src bucket. (5) downstream ETL FIFO queue + SQS-trigger Lambda + Glue run history. Note: the pile of old `.tar` files in `unprocessed/` does NOT prove the S3-notification path is currently live. User plans to deploy and retest tomorrow AM.
+*Relevance: high*
+
+*Context: Phase 1 testing: direct S3 dump to unprocessed/ did not trigger the ETL*
+
+*Tags: seqauto etl s3-notification troubleshooting deploy dynamodb glue*
+---
+*Observed: 2026-08-04T20:49:24.976Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-etl-sinks-never-get-s3-notifications-today-notify-type-union.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-etl-sinks-never-get-s3-notifications-today-notify-type-union.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: ETL sinks never get S3 notifications today; notify type + union-iteration closes the gap"
+slug: obs-2026-08-04-etl-sinks-never-get-s3-notifications-today-notify-type-union
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T17:26:03.015Z
+tags: ["cape-cod", "datalake", "etl", "notifications", "sink-gap", "bucketnotification", "plan"]
+source_context: "Plan-mode design for seqauto notify plumbing; tracing ETL src/sink coupling and notification wiring"
+---
+# ⭐ Observation: ETL sinks never get S3 notifications today; notify type + union-iteration closes the gap
+Real gap found in cape-cod datalake ETL notification wiring: configure_src_bucket_notifications (capeinfra/datalake/datalake.py) attaches an S3 BucketNotification ONLY to buckets in self.sources, and self.sources is populated exclusively from ETL `src` (cfg["src"]) in configure_etl. Nothing ever attaches a notification to a bucket that is only an ETL `sink`. Consequence: you can configure an ETL that writes output to a clean bucket, but nothing can react to that output landing - because sinks never get notifications. This is exactly the seqauto pilot case (seqreadarch writes to its sink input-clean and we want to fire on that). Resolution is NOT to loosen the ETL src/sink coupling (each etl[] entry requires a single src and single sink, both resolved via self.buckets[cfg[...]], a modeling choice not an AWS constraint). Instead: the notify consumer type + one assembler change - attach the unified notifier to the UNION of {ETL source buckets} and {notify source buckets (pipelines.data.notify[] src values)}, emitting exactly ONE aws.s3.BucketNotification per bucket (S3 allows only one per bucket; a bucket that is both an ETL src and notify src must dedupe to one notification targeting the single notifier, which dispatches both types by consulting the ETL DDB table AND the notify env rules for the triggering bucket). A notify entry with src=input-clean wires up the sink bucket; notify has no sink so it never re-triggers the coupling. Genuine ETL loosening (list/optional sink, cross-tributary buckets) stays deferred to the Option C config unification. What src/sink wire up: src = S3 trigger attach + Glue role READ grant + ETLAttrs (bucket,prefix) lookup key; sink = Glue role WRITE grant + --SINK_BUCKET_NAME job arg.
+*Relevance: high*
+
+*Context: Plan-mode design for seqauto notify plumbing; tracing ETL src/sink coupling and notification wiring*
+
+*Tags: cape-cod datalake etl notifications sink-gap bucketnotification plan*
+---
+*Observed: 2026-08-04T17:26:03.015Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-instance-profile-grant-is-a-separate-branch-tributary-branch.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-instance-profile-grant-is-a-separate-branch-tributary-branch.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Instance-profile grant is a separate branch; tributary branch only exposes the notify queue"
+slug: obs-2026-08-04-instance-profile-grant-is-a-separate-branch-tributary-branch
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T17:03:08.218Z
+tags: ["cape-cod", "notifications", "plan", "scope", "instance-profile", "branch-boundary"]
+source_context: "Plan-mode scoping of seqauto notify plumbing branch vs instance-profile branch"
+---
+# ⭐ Observation: Instance-profile grant is a separate branch; tributary branch only exposes the notify queue
+Scope split for the seqauto notify plumbing work: the external-consumer EC2 instance-profile grant wiring (adding an object-sync service to _create_instance_profile in capeinfra/swimlanes/private.py) is handled in a SEPARATE branch, not the tributary branch. The tributary branch does NOT touch private.py. Its only obligation toward the consumer is an interface contract: create the notify FIFO queue and expose it as a discoverable component attribute (mirroring capeinfra.data_lakehouse.athena_results_bucket) so the separate branch can grant consume_msg on it; input-clean and result-raw already exist with read/write policies. The tributary branch's pulumi preview should show NO private.py / instance-profile changes. Tributary-branch scope: generalize the notifier Lambda into the unified glue-etl/notify mediator, per-bucket BucketNotification assembly, the notify FIFO queue, seqauto input-clean notify config, and the etl_seqarchive.py new-format output, keeping etl[]/EtlJob/ETLAttrs behavior unchanged.
+*Relevance: high*
+
+*Context: Plan-mode scoping of seqauto notify plumbing branch vs instance-profile branch*
+
+*Tags: cape-cod notifications plan scope instance-profile branch-boundary*
+---
+*Observed: 2026-08-04T17:03:08.218Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-notifier-replacement-risk-preserve-logical-identity-or-risk-.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-notifier-replacement-risk-preserve-logical-identity-or-risk-.md
@@ -1,0 +1,25 @@
+---
+type: source
+title: "Observation: Notifier replacement risk: preserve logical identity or risk a silent ingest-notification gap"
+slug: obs-2026-08-04-notifier-replacement-risk-preserve-logical-identity-or-risk-
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T19:07:39.126Z
+tags: ["pulumi", "lambda", "replacement", "datalake", "notifications", "risk"]
+source_context: "Grill-me on the tributary notification plumbing design (seqauto pilot)"
+---
+# ⭐ Observation: Notifier replacement risk: preserve logical identity or risk a silent ingest-notification gap
+Grill outcome. Option B runtime-only unification reuses ONE shared notifier Lambda per tributary (Pulumi logical name `{self.name}-lmbdtrgfnct`, role `{self.name}-s3trgrole`, per-src `{self.name}-{src}-allow-lmbd` and `{self.name}-{src}-s3ntfn`; the Lambda has no explicit physical name arg, so it is Pulumi-autonamed from the logical name). Because it is autonamed, changing code, env vars, or the inline role policy are IN-PLACE updates; replacement is triggered only by renaming a logical resource or touching an immutable field.
+
+Risk if a refactor accidentally renames a notifier resource and that reaches deploy: the Lambda is recreated with a new ARN, the per-bucket Permission + BucketNotification must repoint, and during that window s3:ObjectCreated events on the SHARED ingest path can fail to invoke and - with no DLQ (out of scope) - be silently dropped after S3's few async retries. Net effect is a brief, silent ingest-notification gap for hai/genomics/seqauto (uploaded files never trigger their ETL).
+
+Mitigations baked into the plan (not just "remember to check"): (1) preserve resource identity by construction - keep the exact logical names, only ADD the notify env var, the notify-queue put_msg statement, and the new input-clean permission/notification; (2) a unit test asserts notifier logical-name identity + unchanged ETL env when no notify config exists; (3) any replace/delete on the notifier, its role, its permissions, or existing BucketNotifications in `pulumi preview --diff` is a STOP condition before deploy.
+*Relevance: high*
+
+*Context: Grill-me on the tributary notification plumbing design (seqauto pilot)*
+
+*Tags: pulumi lambda replacement datalake notifications risk*
+---
+*Observed: 2026-08-04T19:07:39.126Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-notify-config-schema-option-a-sibling-list-pipelines-data-no.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-notify-config-schema-option-a-sibling-list-pipelines-data-no.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Notify config schema: Option A sibling list pipelines.data.notify[]"
+slug: obs-2026-08-04-notify-config-schema-option-a-sibling-list-pipelines-data-no
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T17:12:58.886Z
+tags: ["cape-cod", "notifications", "config-schema", "pipelines", "datalake", "plan"]
+source_context: "Plan-mode design for seqauto S3->SQS notify plumbing; notify config schema shape"
+---
+# ⭐ Observation: Notify config schema: Option A sibling list pipelines.data.notify[]
+Notify config schema for the seqauto notify plumbing branch is DECIDED as Option A: a sibling list pipelines.data.notify[] parallel to pipelines.data.etl[], parsed with config.get("pipelines","data","notify",default=[]) - the same convention etl[] uses. Each notify entry: name (becomes the message `notification` field), src (bucket id, e.g. input-clean), prefix, suffixes[], and optional queue (default = per-tributary sync queue). Mirrors an etl entry minus script/sink. Chosen over Option B (bucket-level buckets.<id>.notifications[] mirroring the optional crawler block) because it keeps notify in the pipelines family as a consumer type alongside etl, matching the one-mechanism/consumer-types model. Option C (migrate etl[] into a single typed consumers list) is the deferred long-term target, out of scope this branch because it churns hai/genomics/seqauto config + auto-gen public YAML + configure_etl. The datalake wiring reads pipelines.data.notify[], groups by src bucket, and passes per-bucket notify rules + notify-queue name into the unified notifier env. etl[] config stays unchanged. With this, all design decisions for the tributary branch are resolved.
+*Relevance: high*
+
+*Context: Plan-mode design for seqauto S3->SQS notify plumbing; notify config schema shape*
+
+*Tags: cape-cod notifications config-schema pipelines datalake plan*
+---
+*Observed: 2026-08-04T17:12:58.886Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-notify-consumer-creds-via-ec2-instance-profile-object-sync-s.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-notify-consumer-creds-via-ec2-instance-profile-object-sync-s.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Notify consumer creds via EC2 instance profile (object-sync service in private swimlane)"
+slug: obs-2026-08-04-notify-consumer-creds-via-ec2-instance-profile-object-sync-s
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T17:00:34.087Z
+tags: ["cape-cod", "iam", "instance-profile", "private-swimlane", "notifications", "s3-mount", "plan"]
+source_context: "Plan-mode design for seqauto S3->SQS notify plumbing; external-consumer credential model"
+---
+# ⭐ Observation: Notify consumer creds via EC2 instance profile (object-sync service in private swimlane)
+For the seqauto notify plumbing branch, external-consumer credentials are delivered via the consumer VM's EC2 instance profile (no IAM user / access keys). The VM is a cape-managed private-swimlane app instance whose profile is built by _create_instance_profile in capeinfra/swimlanes/private.py from a per-instance `services` list. Plan: add a new generic service (e.g. object-sync) to that if-ladder granting consume_msg on the notify FIFO queue, READ on seqauto input-clean, and READ+WRITE on seqauto result-raw, all mount-compatible (s3:ListBucket + GetObject/PutObject for mountpoint-s3 - the VM does S3 read/write over an S3 mount). Reference the queue/buckets via component lookups mirroring the existing athena service that reaches capeinfra.data_lakehouse.athena_results_bucket; do NOT reuse the blanket read-only `s3` service. Open implementation-time details: which instance-app config entry gets the service, and whether the notify-queue + result-raw references resolve at instance-profile construction time given datalake-Tributary vs swimlane ordering. Existing IAM building blocks: get_instance_profile, get_bucket_reader_policy, get_inline_role, SQSQueue consume/put grants.
+*Relevance: high*
+
+*Context: Plan-mode design for seqauto S3->SQS notify plumbing; external-consumer credential model*
+
+*Tags: cape-cod iam instance-profile private-swimlane notifications s3-mount plan*
+---
+*Observed: 2026-08-04T17:00:34.087Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-notify-fifo-group-id-per-key-event-derived-event-time-static.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-notify-fifo-group-id-per-key-event-derived-event-time-static.md
@@ -1,0 +1,25 @@
+---
+type: source
+title: "Observation: Notify FIFO group id per-key + event-derived event_time; static ETL group id is a latent serial limit"
+slug: obs-2026-08-04-notify-fifo-group-id-per-key-event-derived-event-time-static
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T19:07:20.935Z
+tags: ["sqs", "fifo", "messagegroupid", "dedup", "datalake", "notifications"]
+source_context: "Grill-me on the tributary notification plumbing design (seqauto pilot)"
+---
+# ⭐ Observation: Notify FIFO group id per-key + event-derived event_time; static ETL group id is a latent serial limit
+Grill outcome. The new seqauto notify FIFO queue will use a PER-OBJECT-KEY MessageGroupId (not the static id the ETL queues use), and the notify message body's `event_time` must be sourced from the S3 record's `eventTime`/sequencer, never Lambda wall-clock, so content-based dedup collapses S3 at-least-once redeliveries within the 5-minute FIFO window.
+
+Key facts established: MessageGroupId is queue-local and never couples two queues, so mixing group-id strategies across queues has no system-level downside - it only sets, within one queue, ordering scope (strict per group) and the parallelism/head-of-line ceiling (one in-flight message per active group). Per-key isolates head-of-line blocking to a single key and enables parallel delivery across keys, and is strictly more flexible even for a single-threaded puller (enables concurrency without requiring it). FIFO throughput cap is 300 msg/s (3000 batched) regardless of group count, far above seqauto volume.
+
+LATENT LIMITATION noted (NOT fixed this branch): the existing ETL notifier uses a single static group id `f"{queue_name}-raw-data-msg"`, which serializes each ETL queue - a stuck message head-of-line blocks the rest until visibility timeout/DLQ. Retrofitting it touches deployed ETL behavior and belongs in the deferred ETL-consolidation pass. Add a one-line rationale comment on each queue so the two conventions read intentionally.
+*Relevance: high*
+
+*Context: Grill-me on the tributary notification plumbing design (seqauto pilot)*
+
+*Tags: sqs fifo messagegroupid dedup datalake notifications*
+---
+*Observed: 2026-08-04T19:07:20.935Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-notify-message-contract-metadata-rich-versioned-for-future-d.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-notify-message-contract-metadata-rich-versioned-for-future-d.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Notify message contract: metadata-rich + versioned (for future data-progress tracking)"
+slug: obs-2026-08-04-notify-message-contract-metadata-rich-versioned-for-future-d
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T17:06:21.804Z
+tags: ["cape-cod", "notifications", "message-contract", "sqs", "plan", "data-progress-tracking"]
+source_context: "Plan-mode design for seqauto S3->SQS notify plumbing; notify message contract"
+---
+# ⭐ Observation: Notify message contract: metadata-rich + versioned (for future data-progress tracking)
+Notify message contract for the seqauto notify plumbing branch is DECIDED as metadata-rich and versioned (not just {bucket,key}), motivated by a future goal of tracking data progress through pipelines so a user can see where their data sits. JSON body fields: schema_version (versioned for evolution), event_time, event_name, bucket, key, size, etag, tributary (cape context), notification (the matched notify rule name). These are all derivable from the S3 ObjectCreated event record plus cape config context. Sample/pipeline correlation ids are NOT in the S3 event and would be derived from the object key per-consumer later if needed. FIFO MessageGroupId and content-based dedup are transport-level concerns, separate from the message body. The existing ETL message stays {bucket, key, etl_job} unchanged. With this, no blocking design choices remain for the tributary branch.
+*Relevance: high*
+
+*Context: Plan-mode design for seqauto S3->SQS notify plumbing; notify message contract*
+
+*Tags: cape-cod notifications message-contract sqs plan data-progress-tracking*
+---
+*Observed: 2026-08-04T17:06:21.804Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-phased-commit-order-data-centric-framing-for-the-notificatio.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-phased-commit-order-data-centric-framing-for-the-notificatio.md
@@ -1,0 +1,25 @@
+---
+type: source
+title: "Observation: Phased commit order + data-centric framing for the notification branch"
+slug: obs-2026-08-04-phased-commit-order-data-centric-framing-for-the-notificatio
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: medium
+observed_at: 2026-08-04T19:07:49.344Z
+tags: ["process", "phasing", "commit-order", "naming", "open-source", "datalake"]
+source_context: "Grill-me on the tributary notification plumbing design (seqauto pilot)"
+---
+# 🔍 Observation: Phased commit order + data-centric framing for the notification branch
+Process conventions for the seqauto notification-plumbing branch.
+
+Phased, left-to-right along the user-interaction timeline, one commit per phase: Phase 1 = ETL split-reads output to input-clean + the one crawler-exclude line (standalone, independent of the notifier, deployable/demoable alone); Phase 2 = notifier generalization (glue-etl + notify types) + union per-bucket BucketNotification assembler + notify FIFO queue + pipelines.data.notify[] config (this phase touches the shared notifier, so the replacement guard applies here); Phase 3 = expose the notify queue as a discoverable component attribute for the separate VM branch. Cross-phase coupling to keep in sync: the Phase 2 notify rule prefix must equal the Phase 1 split prefix (both sequencing-reads-split). Phase 2 can be tested independently by writing directly to that prefix, so it is not hard-blocked by Phase 1.
+
+Framing constraint (open-source repo): committable artifacts (config keys, resource names, comments, docs, message field values) must be framed around the DATA and TRANSFORMS - objects landing in the datalake and the notifications they raise - and must NOT name OR imply an unnamed downstream app that consumes them. Prefer data/notification-centric names: notify rule `split-reads` (becomes the message `notification` field), a notification-centric queue name (not `sync`), object-landing comments. The `object-sync` instance-profile service naming lives in the separate VM branch. Plan-internal references to the consumer are for shared understanding only and must not leak into committed code/config/comments.
+*Relevance: medium*
+
+*Context: Grill-me on the tributary notification plumbing design (seqauto pilot)*
+
+*Tags: process phasing commit-order naming open-source datalake*
+---
+*Observed: 2026-08-04T19:07:49.344Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-split-reads-etl-output-layout-format-agnostic-notify-match.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-split-reads-etl-output-layout-format-agnostic-notify-match.md
@@ -1,0 +1,23 @@
+---
+type: source
+title: "Observation: Split-reads ETL output layout + format-agnostic notify match"
+slug: obs-2026-08-04-split-reads-etl-output-layout-format-agnostic-notify-match
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T19:07:20.934Z
+tags: ["seqauto", "etl", "datalake", "notifications", "crawler"]
+source_context: "Grill-me on the tributary notification plumbing design (seqauto pilot)"
+---
+# ⭐ Observation: Split-reads ETL output layout + format-agnostic notify match
+Grill outcome for the seqauto notification work. The updated seqreadarch ETL (assets/etl/etl_seqarchive.py) will write the individual (un-concatenated) per-read files to input-clean under a NEW dedicated TOP-LEVEL prefix `sequencing-reads-split/<sink_prefix>/<name>.<ext>`, reusing the existing Hive-style partition path (sample_id=.../year=.../.../second=...). The existing concatenated output stays put at `sequencing-reads/<sink_prefix>/sequencing-reads.gz` (do NOT move it - it is referenced by the cataloged meta.csv `sequencing_reads` column). One crawler-exclude line `sequencing-reads-split/**` is added to the input-clean crawler (which already excludes `sequencing-reads/**`).
+
+Decision rationale: the individual files may be `.fastq` OR `.gz` depending on instrument, so a suffix-based notify match is unreliable (gz would collide with the concat). Instead the notify rule matches by the dedicated prefix `sequencing-reads-split` alone (format-agnostic), reusing the notifier's existing leading-prefix ancestor-walk (topmost ancestor equals the prefix). A dedicated TOP-LEVEL prefix was chosen over nesting under sequencing-reads specifically so a simple leading-prefix match works without a new glob/segment matcher; the cost is the one extra crawler-exclude line. Default output format is gzip per file (storage-sane, matches the concat rationale); final format is consumer-driven and can be converted at VM-copy time without touching the notify wiring. input-clean is NOT an ETL source in seqauto, so writing here cannot re-trigger an ETL (no loop).
+*Relevance: high*
+
+*Context: Grill-me on the tributary notification plumbing design (seqauto pilot)*
+
+*Tags: seqauto etl datalake notifications crawler*
+---
+*Observed: 2026-08-04T19:07:20.934Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-04-tributary-notify-plumbing-chose-option-b-runtime-only-notifi.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-04-tributary-notify-plumbing-chose-option-b-runtime-only-notifi.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Tributary notify plumbing: chose Option B (runtime-only notifier unification)"
+slug: obs-2026-08-04-tributary-notify-plumbing-chose-option-b-runtime-only-notifi
+status: observation
+created: 2026-08-04
+updated: 2026-08-04
+relevance: high
+observed_at: 2026-08-04T16:45:00.752Z
+tags: ["cape-cod", "datalake", "notifications", "sqs", "etl", "pulumi", "plan"]
+source_context: "Plan-mode design for config-driven tributary S3->SQS notification plumbing (seqauto pilot)"
+---
+# ⭐ Observation: Tributary notify plumbing: chose Option B (runtime-only notifier unification)
+For the seqauto S3->SQS notification plumbing branch, the delivery approach was decided as Option B "runtime-only unification": generalize the single notifier Lambda (assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py) into a rule-driven mediator with two consumer types (glue-etl = existing ETLAttrs/DDB lookup emitting {bucket,key,etl_job} to the ETL FIFO queue; notify = config-driven prefix/suffix rules emitting a cape-owned message to a new notify FIFO queue), and generalize configure_src_bucket_notifications in capeinfra/datalake/datalake.py to assemble all of a bucket's targets into one aws.s3.BucketNotification. Kept unchanged: etl[] config, configure_etl, EtlJob, ETLAttrs, ETL queue/trigger behavior (proven via pulumi preview showing in-place notifier Lambda/role updates, not replace). Chosen over A-prime (separate notifier now, ETL cutover later) for PATTERN COHERENCE - avoiding two parallel notifier subsystems a future tributary author must choose between - not for fan-out. seqauto has no same-bucket fan-out: the seqreadarch ETL triggers on input-raw and the notify rule watches input-clean. The branch also updates etl_seqarchive.py to add an additional transform writing a new-format output to input-clean under a new prefix/suffix, which is what the external consumer's notify rule watches. Rationale accepted because the full end-to-end path must be exercised for the demo regardless, so B adds only hai regression + preview scrutiny, not new demo testing. Plan captured in PLAN.md.
+*Relevance: high*
+
+*Context: Plan-mode design for config-driven tributary S3->SQS notification plumbing (seqauto pilot)*
+
+*Tags: cape-cod datalake notifications sqs etl pulumi plan*
+---
+*Observed: 2026-08-04T16:45:00.752Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-05-backlog-stop-nextflow-ecr-image-rebuilding-every-pulumi-up-a.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-05-backlog-stop-nextflow-ecr-image-rebuilding-every-pulumi-up-a.md
@@ -1,0 +1,135 @@
+---
+type: source
+title:
+    "Nextflow ECR image rebuilds every pulumi up: root cause, fixes, and backlog
+    to stop it"
+slug: obs-2026-08-05-backlog-stop-nextflow-ecr-image-rebuilding-every-pulumi-up-a
+status: observation
+created: 2026-08-05
+updated: 2026-08-05
+relevance: medium
+observed_at: 2026-08-05T17:07:03.971Z
+tags:
+    [
+        "backlog",
+        "deferred",
+        "pulumi",
+        "awsx",
+        "ecr",
+        "docker-build",
+        "image-rebuild",
+        "devops",
+        "dockerhub",
+        "buildkit",
+        "dns",
+        "vpn",
+    ]
+source_context:
+    "Nextflow image rebuild churn + Docker Hub base-image build timeout
+    identified during the seqauto split-reads branch"
+---
+
+# Nextflow ECR image rebuilds every pulumi up: root cause, fixes, and backlog to stop it
+
+The `nextflow_kickstart` ECR image rebuilds on almost every `pulumi up`, which
+wastes deploy time and periodically breaks deploys outright. DEFERRED / BACKLOG:
+do not spend current-feature time on this; pick it up on its own branch, not the
+ETL/split-reads branch.
+
+## Symptom
+
+Intermittent `pulumi up` failure both infra devs hit, unrelated to any specific
+branch:
+
+```
+docker-build:index:Image (ccd-pvsl-repo-nextflow_kickstart):
+  error: failed to solve: DeadlineExceeded: amazoncorretto:21.0.8: failed to resolve source metadata for docker.io/library/amazoncorretto:21.0.8: failed to do request: Head "https://registry-1.docker.io/v2/library/amazoncorretto/manifests/21.0.8": dial tcp: lookup registry-1.docker.io: i/o timeout
+Exception: resource monitor shut down
+```
+
+## Root cause
+
+`awsx.ecr.Image` (awsx 3.1.0 / pulumi_docker_build 0.0.15) in
+`capeinfra/pipeline/ecr.py` recomputes and rebuilds the image every deploy even
+though its context dir (`assets/containers/nextflow-kickstart/`, just Dockerfile
+
+- entrypoint.sh) is static and git-clean; the `docker-build:index:Image`
+  contextHash flips to `[unknown]` on almost every preview (one of the known
+  "superfluous" churn resources). Each rebuild bumps the `nextflow-jobdef` Batch
+  revision + its IAM policy and re-resolves the base image
+  `FROM amazoncorretto:21.0.8` against Docker Hub (`registry-1.docker.io`) at
+  build time.
+
+The build times out at the DNS `lookup` step -> BuildKit `DeadlineExceeded` ->
+image build aborts -> Pulumi resource monitor shuts down -> the whole program
+raises `resource monitor shut down`.
+
+## Why intermittent, and the real trigger (VPN split-DNS)
+
+BuildKit only contacts Docker Hub when the base manifest is not cached locally;
+a warm cache resolves offline and succeeds. Because this image rebuilds
+constantly, it re-resolves the base often, so Docker Hub anonymous per-IP pull
+rate limits (worse with a shared egress IP across two devs) plus transient DNS
+blips make some runs fail and others pass.
+
+Confirmed real trigger on the affected machine: DNS resolution of
+`registry-1.docker.io` failing over the VPN. Pulumi and Docker/BuildKit are Go
+binaries; Go's built-in resolver reads `/etc/resolv.conf` directly (bypassing
+nsswitch/systemd-resolved), and NetworkManager had written unreachable uplink
+nameservers there, so every Go-resolver lookup timed out on VPN. Hopping off VPN
+restored a reachable resolver and the build succeeded.
+
+Why `docker pull amazoncorretto:21.0.8` had ZERO effect: BuildKit resolves the
+`FROM` base by querying the registry for the tag's manifest digest (the "failed
+to resolve source metadata" step), independent of the docker CLI's classic local
+image store. The pull populated the legacy store, which BuildKit does not
+consult for base resolution, so BuildKit still issued the registry HEAD through
+the broken Go resolver and timed out. Misleading asymmetry: `docker pull` via
+dockerd resolves through libc/nsswitch -> systemd-resolved (works on VPN), while
+BuildKit's Go resolver read the broken `/etc/resolv.conf` (fails) - same box,
+opposite outcomes.
+
+## Fixes / workarounds, cheapest first
+
+1. Re-run `pulumi up` - transient; the aborted update is partial and a clean
+   re-run finishes the rest.
+2. `docker login` to Docker Hub - authenticated pulls have much higher rate
+   limits than anonymous per-IP.
+3. Point the Docker daemon at VPN-resolvable DNS in `/etc/docker/daemon.json`
+   (e.g. the VPN nameservers) so the buildkitd container inherits a working
+   resolver; revert when off VPN. This stays at the daemon layer and avoids
+   editing `/etc/resolv.conf`. Do NOT globally symlink `/etc/resolv.conf` to the
+   systemd-resolved stub on this machine - that breaks GTRI VPN DNS.
+
+Note: even with healthy DNS, BuildKit still does a tag->digest HEAD against the
+registry each build unless the base is pinned by an already-cached digest or fed
+via local OCI/build-context, so "pre-pull to go offline" does not work with
+BuildKit the way it does with the legacy (`DOCKER_BUILDKIT=0`) builder. The real
+win is stopping the rebuilds so routine deploys never touch any registry; the
+occasional genuine rebuild is then handled by `docker login` + the daemon DNS
+fix.
+
+## Backlog: stop the rebuilds (own branch, not the ETL/split-reads branch)
+
+1. Cheap path first: bump `pulumi_docker_build` (0.0.15 is ancient) and/or
+   `pulumi-awsx`, then `pulumi preview` on an unrelated change to see if the
+   image goes quiet (stable context hash). Near-zero code if it works.
+2. If not: replace `awsx.ecr.Image` with `pulumi_docker_build.Image` directly
+   (content-hashes the context, no-ops when unchanged); trade-off is wiring
+   `registries=[...]` ECR auth (`aws.ecr.get_authorization_token`) since we lose
+   awsx's push convenience.
+
+Key correction: moving the base into ECR (pull-through cache) does NOT dodge the
+VPN DNS failure alone - the build runs in the dev's buildkitd container, which
+resolves via Docker's unreachable `8.8.8.8` fallback, so it would fail to
+resolve the ECR hostname too. Stopping rebuilds is the durable win. User is
+interested but explicitly deferred until the current feature is done.
+
+## Related
+
+- [[sources/obs-2026-08-05-pulumi-preview-for-seqauto-split-reads-2-in-scope-changes-9-]] -
+  pre-deploy churn context.
+
+---
+
+_Observed: 2026-08-05T17:07:03.971Z_

--- a/.llm-wiki/wiki/sources/obs-2026-08-05-glue-etl-job-role-missing-s3-read-on-capepy-wheel-data-py-et.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-05-glue-etl-job-role-missing-s3-read-on-capepy-wheel-data-py-et.md
@@ -1,0 +1,31 @@
+---
+type: source
+title: "Observation: Glue ETL job role missing S3 read on capepy wheel (data.py EtlJob) - blocks job launch, second refactor casualty"
+slug: obs-2026-08-05-glue-etl-job-role-missing-s3-read-on-capepy-wheel-data-py-et
+status: observation
+created: 2026-08-05
+updated: 2026-08-05
+relevance: high
+observed_at: 2026-08-05T16:44:37.064Z
+tags: ["etl", "glue", "iam", "capepy", "wheel", "s3", "permissions", "refactor", "phase1"]
+source_context: "Post-deploy ETL retest: notifier fix worked, Glue job role missing capepy wheel read"
+---
+# ⭐ Observation: Glue ETL job role missing S3 read on capepy wheel (data.py EtlJob) - blocks job launch, second refactor casualty
+After the notifier DDB-table-name fix deployed, the seqauto ETL trigger chain now works end-to-end up to the Glue job LAUNCH, confirming that fix. New blocker surfaced: the Glue ETL job role fails at launch with S3 403 downloading the capepy wheel:
+
+`User: .../ccd-dlh-T-seqauto-ETL-seqreadarch-role-808014e/GlueJobRunnerSession is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::ccd-meta-assets-vbkt-s3-8b7134e/capepy-3.0.0-py3-none-any.whl`
+
+Root cause (same late-2025 refactor casualty): in `capeinfra/pipeline/data.py`, the `EtlJob.etl_role` grants S3 read on the script bucket scoped ONLY to `{arn}/{self.config['script']}` (the ETL script object). But the Glue job also downloads the capepy wheel at launch via `--additional-python-modules` (`default_arguments=capeinfra.meta.capepy.uri.apply(add_to_python_modules)`), and that wheel object (`capepy-3.0.0-py3-none-any.whl` at the meta-assets bucket root) is NOT in the grant. The capepy-as-additional-python-modules wiring landed 2025-12-05 (commit 4b814903, Micah) without expanding the role grant.
+
+Fix applied (uncommitted, gated): added a statement to `EtlJob.etl_role` granting `script_bucket.policies[read]` on the capepy wheel object ARN, derived version-agnostically from `capeinfra.meta.capepy.uri.replace("s3://", "arn:aws:s3:::")`. `python -m py_compile capeinfra/pipeline/data.py` passes; diff is the single inserted block, no ruff churn.
+
+Note: pi-lens flagged a false-positive "L268 __init__ should not return a value" - that `return default_args` is inside the nested `add_to_python_modules` closure (def at line 262), not `__init__` (line 168); valid Python, pre-existing, untouched.
+
+Retest note: the prior S3 event was already consumed (notifier enqueued -> sqs lambda StartJobRun succeeded -> job failed at launch, no auto-retry), so after deploying this fix the object must be re-uploaded (or the Glue job manually re-run) to re-trigger. This bug affects all tributaries' ETL jobs, not just seqauto. See [[sources/etl-notifier-ddb-table-name-mismatch]].
+*Relevance: high*
+
+*Context: Post-deploy ETL retest: notifier fix worked, Glue job role missing capepy wheel read*
+
+*Tags: etl glue iam capepy wheel s3 permissions refactor phase1*
+---
+*Observed: 2026-08-05T16:44:37.064Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-05-phase-2-notify-path-validated-end-to-end-in-cape-cod-dev-6-m.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-05-phase-2-notify-path-validated-end-to-end-in-cape-cod-dev-6-m.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Phase 2 notify path validated end-to-end in cape-cod-dev (6 messages, load test)"
+slug: obs-2026-08-05-phase-2-notify-path-validated-end-to-end-in-cape-cod-dev-6-m
+status: observation
+created: 2026-08-05
+updated: 2026-08-05
+relevance: high
+observed_at: 2026-08-05T19:44:39.124Z
+tags: ["seqauto", "notify", "sqs", "lambda", "phase2", "validation", "dev"]
+source_context: "cape-cod Phase 2 notify-queue live validation in cape-cod-dev"
+---
+# ⭐ Observation: Phase 2 notify path validated end-to-end in cape-cod-dev (6 messages, load test)
+Phase 2 config-driven S3->SQS notify path validated end-to-end in cape-cod-dev after redeploy. Test: deleted all prior sequencing-reads-split artifacts + meta + sequencing-reads originals, re-uploaded both plainreads and gzreads tar.gz files simultaneously (highest available load). Results: ETL ran correctly (unchanged behavior); the unified notifier Lambda (ccd-dlh-T-seqauto-lmbdtrgfnct, physical id ...-f1ac78a) was invoked as expected; exactly 6 messages landed on the notify queue ccd-dlh-T-seqauto-ntfq-q.fifo (3 archived parts per tar.gz x 2 files), confirming per-object-key MessageGroupId parallelism and prefix filtering (only sequencing-reads-split objects notified, no leakage from other input-clean writes/meta). User confirmed message body contract, filtering, notifier CloudWatch (no errors/throttles), and queue attributes (FifoQueue, ContentBasedDeduplication, MessageRetentionPeriod=43200/12h) all look as expected. Pulumi preview earlier showed 4 creates + in-place updates only, no replaces/deletes; logical resource identity of the shared notifier/role/ETL queue preserved. Notify config is present-if-configured: hai/genomics tributaries get code-only lambda update and remain no-op without notify env. Consumer (EC2 instance-profile) and result write-back target remain a separate future branch.
+*Relevance: high*
+
+*Context: cape-cod Phase 2 notify-queue live validation in cape-cod-dev*
+
+*Tags: seqauto notify sqs lambda phase2 validation dev*
+---
+*Observed: 2026-08-05T19:44:39.124Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-05-phase-2-notify-queue-feature-added-to-sqsqueue-and-s3-notifi.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-05-phase-2-notify-queue-feature-added-to-sqsqueue-and-s3-notifi.md
@@ -1,0 +1,27 @@
+---
+type: source
+title: "Observation: Phase 2 notify-queue feature added to SQSQueue and S3 notifier lambda"
+slug: obs-2026-08-05-phase-2-notify-queue-feature-added-to-sqsqueue-and-s3-notifi
+status: observation
+created: 2026-08-05
+updated: 2026-08-05
+relevance: high
+observed_at: 2026-08-05T18:20:44.889Z
+tags: ["sqs", "lambda", "s3-notifications", "queue.py", "phase2"]
+source_context: "Phase 2 of config-driven S3->SQS notification feature, dispatched as a two-file Fixer task"
+---
+# ⭐ Observation: Phase 2 notify-queue feature added to SQSQueue and S3 notifier lambda
+Implemented Phase 2 (config-driven S3->SQS notify path) across two files: capeinfra/resources/queue.py and assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py.
+
+queue.py: SQSQueue.__init__ gained an optional message_retention_seconds: int | None = None kwarg, forwarded to aws.sqs.Queue only when not None (via a queue_kwargs dict built up before the Queue() call), so existing queues get no diff. SQS range is 60..1209600 seconds (14 days); default is 4 days.
+
+new_s3obj_queue_notifier_lambda.py: kept the existing glue-etl path (env QUEUE_NAME, EtlTable, BucketNotificationRecord, static MessageGroupId f"{queue_name}-raw-data-msg") completely untouched. Added an additive notify path gated by three new env vars that are absent by default: NOTIFY_QUEUE_NAME, NOTIFY_RULES (JSON: {bucket: [{"name","prefix","suffixes"}]}), TRIBUTARY_NAME. Added pure functions match_notify_rules(bucket, key, rules) -> list[str] and build_notify_message(raw_record, bucket, key, tributary_name, notification) -> dict for unit testability without AWS, plus send_notify_message() mirroring send_etl_message()'s try/except style. Notify messages use MessageGroupId = the object key (per-object dedup/parallelism) instead of the ETL path's static group id. capepy's BucketNotificationRecord (capepy/aws/lambda_.py) only exposes .bucket and .key; eventTime/eventName/s3.object.size/s3.object.eTag must be read from the raw record dict directly.
+
+Also learned: repo already had a pre-existing ruff-format violation in queue.py (the `def policies(self) -> dict[...]` multi-line return type) unrelated to this change - confirmed via git stash before/after. Two pre-existing pytest failures unrelated to this work: tests/test_capemeta.py::test_asset_bucket (needs real AWS creds) and tests/test_datalake.py::test_catalog.
+*Relevance: high*
+
+*Context: Phase 2 of config-driven S3->SQS notification feature, dispatched as a two-file Fixer task*
+
+*Tags: sqs lambda s3-notifications queue.py phase2*
+---
+*Observed: 2026-08-05T18:20:44.889Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-05-phase-3-notify-queue-exposed-via-config-keyed-datalakehouse-.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-05-phase-3-notify-queue-exposed-via-config-keyed-datalakehouse-.md
@@ -1,0 +1,21 @@
+---
+type: source
+title: "Observation: Phase 3: notify queue exposed via config-keyed DatalakeHouse.notify_queues (no hard-coded names)"
+slug: obs-2026-08-05-phase-3-notify-queue-exposed-via-config-keyed-datalakehouse-
+status: observation
+created: 2026-08-05
+updated: 2026-08-05
+relevance: high
+observed_at: 2026-08-05T20:02:28.221Z
+tags: ["seqauto", "notify", "datalake", "discoverability", "phase3", "instance-profile"]
+source_context: "cape-cod seqauto notify branch Phase 3 - notify queue discoverability"
+---
+# ⭐ Observation: Phase 3: notify queue exposed via config-keyed DatalakeHouse.notify_queues (no hard-coded names)
+Phase 3 (final commit of the seqauto notify branch) exposes the notify queue for the separate consumer-grant branch via DatalakeHouse.notify_queues: a config-keyed dict (key = tributary config name, e.g. \"seqauto\"; value = the tributary's SQSQueue) populated in configure_tributaries only for tributaries whose config declares a notify block (present-if-configured). No tributary name is hard-coded anywhere - keys derive from trib_config.get(\"name\") in the same loop that wills tributaries into being. The separate instance-profile branch resolves capeinfra.data_lakehouse.notify_queues[\"seqauto\"] (mirroring how private.py reaches capeinfra.data_lakehouse.athena_results_bucket - same stack, in-process attribute, no StackReference/export). SQSQueue already exposes PolicyEnum.consume_msg (ReceiveMessage/DeleteMessage/GetQueueAttributes), so the consumer branch attaches that; this branch only exposes the queue object. Resolving a name with no notify queue raises KeyError at synth time (loud fail beats silently granting nothing). notify_queues is pure Python and provisions no AWS resources: pulumi preview -s cape-cod-dev showed 1 update / 474 unchanged, the lone update being pre-existing GTRI-SSO cognito cert-rotation drift, no destructive ops. Still deferred to the separate branch: the private.py instance-profile consume_msg grant and the undecided result write-back target (result-raw vs result-clean).
+*Relevance: high*
+
+*Context: cape-cod seqauto notify branch Phase 3 - notify queue discoverability*
+
+*Tags: seqauto notify datalake discoverability phase3 instance-profile*
+---
+*Observed: 2026-08-05T20:02:28.221Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-05-pulumi-preview-for-seqauto-split-reads-2-in-scope-changes-9-.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-05-pulumi-preview-for-seqauto-split-reads-2-in-scope-changes-9-.md
@@ -1,0 +1,33 @@
+---
+type: source
+title: "Observation: pulumi preview for seqauto split-reads: 2 in-scope changes + 9 pre-existing drift/build churn, no destructive ops"
+slug: obs-2026-08-05-pulumi-preview-for-seqauto-split-reads-2-in-scope-changes-9-
+status: observation
+created: 2026-08-05
+updated: 2026-08-05
+relevance: high
+observed_at: 2026-08-05T14:29:33.943Z
+tags: ["pulumi", "preview", "seqauto", "etl", "phase1", "drift", "deploy"]
+source_context: "Phase 1 pre-deploy pulumi preview evaluation"
+---
+# ⭐ Observation: pulumi preview for seqauto split-reads: 2 in-scope changes + 9 pre-existing drift/build churn, no destructive ops
+Ran `pulumi preview --diff -s cape-cod-dev` for the seqauto split-reads branch (361-...). Result: 10 to update, 1 to replace, 460 unchanged. Token was live; preview took a few minutes (rebuilt report-gen lambda layer + resolved deps).
+
+The 2 changes attributable to THIS branch, both correct and non-destructive:
+- `aws:s3/bucketObjectv2` `glue/etl/etl_seqarchive.py` - script asset hash 0c445c3 -> 80cacf6 (the split-reads ETL edit; Glue job needs no change, it references the object).
+- `aws:glue/crawler:Crawler` `ccd-dlh-T-seqauto-input-clean-vbkt-crwl-gcrwl` - exclusions add `[1]: "sequencing-reads-split/**"` next to existing `sequencing-reads/**`.
+
+The other 9 are pre-existing drift / build-nondeterminism churn, NOT from this branch:
+- report-gen lambda layer rebuild (4): `report-gen/manifest.txt` + `report-gen/layer.zip` asset hashes change -> forces `report-gen` LayerVersion REPLACE (the single +-1) -> `getcannedreport` function layers[1] -> [unknown]. Caused by pip re-resolving weasyprint/jinja deps into a new layer hash at preview time.
+- nextflow image rebuild (3): `docker-build:index:Image` contextHash -> [unknown], cascading to `nextflow-jobdef` Batch job definition + its `nextflow-jobdef-pssrl-plcy` IAM policy.
+- `aws:cognito/identityProvider` GTRI-SSO providerDetails drops SSO cert + redirect URIs (real SSO-side drift).
+- `aws:cognito/user` demo@example.com temporaryPassword [secret]=>[secret] (perpetual secret diff).
+
+Safety: no shared stateful resources (buckets/DBs/queues) deleted or replaced; the only replace is an immutable Lambda layer version (safe). Caveat for deploy: a `pulumi up` would also apply the 9 unrelated changes - with two devs on the infra, confirm the report-gen/nextflow churn and cognito drift are expected (not a colleague's in-flight work) before the user deploys. See [[concepts/testing-and-pulumi-preview-workflow]].
+*Relevance: high*
+
+*Context: Phase 1 pre-deploy pulumi preview evaluation*
+
+*Tags: pulumi preview seqauto etl phase1 drift deploy*
+---
+*Observed: 2026-08-05T14:29:33.943Z*

--- a/.llm-wiki/wiki/sources/seqarchive-split-reads-phase1-implemented.md
+++ b/.llm-wiki/wiki/sources/seqarchive-split-reads-phase1-implemented.md
@@ -1,0 +1,24 @@
+---
+type: source
+title: "seqarchive ETL: Phase 1 split-reads output implemented (uncommitted)"
+slug: seqarchive-split-reads-phase1-implemented
+status: insight
+created: 2026-08-04
+updated: 2026-08-04
+category: architecture
+---
+# seqarchive ETL: Phase 1 split-reads output implemented (uncommitted)
+Phase 1 of the seqauto split-reads work is implemented on branch `361-update-seqauto-tributary-...`, verified, and awaiting the user's deploy/test before commit.
+
+**Changes (both uncommitted in the working tree):**
+- `assets/etl/etl_seqarchive.py`: inside the existing `sequencing/` member loop, after the concat write, each member is ALSO written on its own to `sequencing-reads-split/<sink_prefix>/<basename>`, reusing the already-computed `bytes_for_concat`. fasta/fastq members are gzipped (name gets `.gz`); already-gzipped members pass through unchanged. One consistent gzip format. Existing concat output (`sequencing-reads/<sink_prefix>/sequencing-reads.gz`) and `meta/<sink_prefix>/meta.csv` are untouched. Top module comment updated to mention the split output.
+- `Pulumi.cape-cod-dev.yaml`: seqauto `input-clean` crawler `excludes` now includes `sequencing-reads-split/**` (a pi-lens autofix reflowed the flow list to multi-line; parses identically).
+
+**Verification (agent-side):** `python -m py_compile` on the ETL script passes; `yaml.safe_load` on the dev config passes; full pytest = 48 passed. The 2 failures (`test_datalake::test_catalog`, `test_capemeta::test_asset_bucket`) are pre-existing AWS `InvalidToken` env failures, unrelated (see [[sources/obs-2026-08-04-fixer-subagent-401-blocked-this-session-test-catalog-test-as]]).
+
+**Status:** parked at the Phase 1 USER TEST GATE. Commit (planned `feat(seqauto): write split per-read files to input-clean`) happens only after the user deploys and confirms. See design in [[sources/obs-2026-08-04-split-reads-etl-output-layout-format-agnostic-notify-match]].
+*Category: architecture*
+---
+*Captured: 2026-08-04*
+## Related
+_Add links to related pages._

--- a/.llm-wiki/wiki/sources/seqarchive-test-archive-recipe.md
+++ b/.llm-wiki/wiki/sources/seqarchive-test-archive-recipe.md
@@ -1,0 +1,36 @@
+---
+type: source
+title: "Building valid test archives for the seqarchive ETL"
+slug: seqarchive-test-archive-recipe
+status: insight
+created: 2026-08-04
+updated: 2026-08-04
+category: devops
+---
+# Building valid test archives for the seqarchive ETL
+Recipe for building a valid input archive for the `seqreadarch` (etl_seqarchive.py) ETL, verified by simulating the real ETL logic.
+
+**Archive:** a tar, plain or gzipped - the ETL opens it with `tarfile.open(fileobj=..., mode="r")` (transparent mode), so both `.tar` and `.tar.gz` read correctly.
+
+**Internal layout:**
+```
+meta.json                       (at archive root)
+sequencing/<read files>         (fasta/fastq, gz or not)
+```
+A bare `sequencing/` directory entry is harmless: `TarFile.getnames()` reports it WITHOUT a trailing slash, so the ETL's `startswith("sequencing/")` filter excludes it and the member loop only sees real files.
+
+**meta.json required keys:** `sampleId`, `sampleType`, `sampleMatrix`, `sampleCollectionLocation`, `sampleCollectionDate`. `sampleId` drives every clean-sink path: `sample_id=<id>/year=.../month=.../day=.../hour=.../minute=.../second=...`. Example real value: `{"sampleId":"abcdefghij","sampleType":"Environmental","sampleMatrix":"Soil","sampleCollectionLocation":"Back yard","sampleCollectionDate":"2025-08-15T14:36:28.024649+00:00"}`.
+
+**ETL behavior per member:** names ending `fasta`/`fastq` are gzipped in place; anything else passes through as-is.
+
+**Upload target:** the seqauto input-raw bucket under `unprocessed/` (ETL `suffixes: [gz, tar]`).
+
+**Test artifacts built this session** (copies only; source data at `/home/lp76/projects/cape/test-data/seqauto/` untouched), at `/home/lp76/projects/cape/test-data/seqauto/etl-split-test/`:
+- `plainreads-fastq.tar.gz` - 3 UNCOMPRESSED `.fastq` members `plainreads_part{A,B,C}.fastq`, `sampleId=plainreads`.
+- `gzreads-fastqgz.tar.gz` - 3 `.fastq.gz` members `gzreads_part{A,B,C}.fastq.gz`, `sampleId=gzreads`.
+Distinct sample ids + filename prefixes make the split outputs obvious. See [[sources/seqauto-etl-s3-trigger-mechanics]] for how upload triggers the run.
+*Category: devops*
+---
+*Captured: 2026-08-04*
+## Related
+_Add links to related pages._

--- a/.llm-wiki/wiki/sources/seqauto-etl-s3-trigger-mechanics.md
+++ b/.llm-wiki/wiki/sources/seqauto-etl-s3-trigger-mechanics.md
@@ -1,0 +1,24 @@
+---
+type: source
+title: "seqauto ETL S3 trigger chain + notifier prefix/suffix matching"
+slug: seqauto-etl-s3-trigger-mechanics
+status: insight
+created: 2026-08-04
+updated: 2026-08-04
+category: architecture
+---
+# seqauto ETL S3 trigger chain + notifier prefix/suffix matching
+How a new object in a seqauto ETL source bucket gets processed (all pre-existing infra; independent of the split-reads change).
+
+**Chain:** S3 `ObjectCreated` -> notifier Lambda -> ETL FIFO SQS queue -> SQS-trigger Lambda -> Glue job.
+
+**Wiring** (`capeinfra/datalake/datalake.py`, `configure_src_bucket_notifications` ~line 527): one notifier Lambda per datalake (`{name}-lmbdtrgfnct`, code = `assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py`, env `QUEUE_NAME`/`ETL_ATTRS_DDB_TABLE`/`DDB_REGION`). For each ETL source bucket it creates a `lambda.Permission` + an `aws.s3.BucketNotification` with `events=["s3:ObjectCreated:*"]` and NO `filter_prefix`/`filter_suffix` - every object create in the bucket invokes the notifier; all filtering is in the Lambda.
+
+**Notifier matching** (`new_s3obj_queue_notifier_lambda.py`, `index_handler`): for each record, `key.rpartition("/")` -> `(prefix, objname)`; `suffix = objname.rpartition(".")[2]` (so `foo.tar.gz` -> `"gz"`, `foo.tar` -> `"tar"`). Then it walks prefixes upward (`prefix = prefix.rpartition("/")[0]`), calling `EtlTable.get_etls(bucket, prefix)`; on a hit, if `suffix in etl_attrs["suffixes"]` it enqueues `{bucket, key, etl_job}` to the ETL FIFO queue with static `MessageGroupId = f"{queue_name}-raw-data-msg"`. No match on any ancestor prefix -> ignored.
+
+**Implications:** the DEPLOYED ETLAttrs DynamoDB table is the runtime source of truth for `(bucket, prefix) -> suffixes/etl_job`, populated by `configure_etl` at deploy time. Changing `prefix`/`suffixes` in `Pulumi.*.yaml` has NO runtime effect until a deploy updates the DDB. Because suffix = final dot-segment, `[gz, tar]` matches both `.tar` and `.tar.gz`. This is the same mediator Lambda the notify work extends - see [[sources/obs-2026-08-04-etl-sinks-never-get-s3-notifications-today-notify-type-union]].
+*Category: architecture*
+---
+*Captured: 2026-08-04*
+## Related
+_Add links to related pages._

--- a/.llm-wiki/wiki/syntheses/tributary-notification-plumbing-design-seqauto-pilot.md
+++ b/.llm-wiki/wiki/syntheses/tributary-notification-plumbing-design-seqauto-pilot.md
@@ -1,0 +1,118 @@
+# Tributary notification plumbing design (seqauto pilot)
+
+Durable design record for the config-driven S3 -> SQS notification work on the
+cape-cod datalake, piloted on `seqauto`. Mirrors `PLAN.md` at the decision level
+so the design survives independently of the plan file. Companion atomic notes:
+[[sources/obs-2026-08-04-delivery-model-locked-extend-mediator-lambda-pattern-eventbr]],
+[[sources/obs-2026-08-04-notify-message-contract-metadata-rich-versioned-for-future-d]],
+[[sources/obs-2026-08-04-notify-config-schema-option-a-sibling-list-pipelines-data-no]],
+[[sources/obs-2026-08-04-instance-profile-grant-is-a-separate-branch-tributary-branch]],
+[[sources/obs-2026-08-04-etl-sinks-never-get-s3-notifications-today-notify-type-union]],
+[[sources/etl-same-bucket-src-sink-notification-loop]].
+
+## Goal
+
+Add reusable, configuration-driven plumbing so new objects landing in any of a
+tributary's four default buckets (`input-raw`, `input-clean`, `result-raw`,
+`result-clean`) can raise an S3 notification onto an SQS queue, with
+enqueue-time filtering so only objects matching a configured prefix/suffix are
+queued. Piloted on `seqauto.input-clean`; usable by any tributary via config
+alone (present-if-configured; no config -> no resources, `hai`/`genomics`
+unchanged). External consumer exists only in `seqauto` for now.
+
+## Locked decisions
+
+- Delivery model: mediator Lambda (extend the existing ETL notifier), NOT
+  EventBridge. Pattern: S3 ObjectCreated -> notifier Lambda (filter, drop
+  non-matches, emit cape-owned message) -> FIFO SQS -> consumer. `SQSQueue`
+  stays FIFO. EventBridge deferred to a future infra pass.
+- ETL path relationship: Option B, RUNTIME-ONLY UNIFICATION. Generalize the one
+  notifier Lambda into a rule-driven mediator with two consumer types: `glue-etl`
+  (existing `ETLAttrs` DDB lookup, emits `{bucket, key, etl_job}` to the ETL FIFO
+  queue) and `notify` (config rules -> notify FIFO queue). UNCHANGED: `etl[]`
+  config, `configure_etl`, `EtlJob`, `ETLAttrs`, `src_data_queue`,
+  `configure_sqs_lambda_target`, the SQS trigger Lambda, and all ETL dispatch
+  behavior. Chosen for pattern coherence (one mechanism, not two parallel
+  notifier subsystems), not for fan-out (seqauto needs none).
+- Queue topology: queue boundary follows CONSUMER/PURPOSE, not tributary. One
+  dedicated notify FIFO queue for the seqauto external consumer, SEPARATE from
+  the ETL queue (different principal, different message class). Shared-vs-per-
+  tributary generalization deferred until a second consumer opts in.
+- Notify config schema: Option A - a sibling list `pipelines.data.notify[]`
+  parallel to `pipelines.data.etl[]`, parsed with
+  `config.get("pipelines","data","notify",default=[])`. Each entry: `name`
+  (-> message `notification` field), `src` (bucket id), `prefix`, `suffixes[]`,
+  optional `queue`. Mirrors an etl entry minus `script`/`sink`. Option B
+  (bucket-level `buckets.<id>.notifications[]`) and Option C (migrate etl[] into
+  one typed consumers list) not chosen; C is the deferred long-term target.
+- Notify message contract (cape-owned, metadata-rich, versioned): JSON body
+  `schema_version`, `event_time`, `event_name`, `bucket`, `key`, `size`, `etag`,
+  `tributary`, `notification`. Motivated by future data-progress tracking.
+  Sample/pipeline correlation ids are not in the S3 event; derive from the key
+  per-consumer later. FIFO MessageGroupId/dedup are transport-level, separate
+  from the body. ETL message stays `{bucket, key, etl_job}`.
+- Consumer credentials: the external consumer runs on a cape-provisioned EC2 app
+  instance (private swimlane); grants roll into the VM's EC2 instance profile
+  (no IAM user/keys), S3 via mountpoint-s3. It needs: consume the notify FIFO
+  queue, READ `input-clean`, READ+WRITE seqauto `result-raw`. The instance-
+  profile grant wiring (`object-sync` service in `_create_instance_profile`,
+  `capeinfra/swimlanes/private.py`) is a SEPARATE branch, NOT this one.
+
+## The real gap this branch closes (sink-side notifications)
+
+Today `configure_src_bucket_notifications` attaches a notification only to
+buckets in `self.sources`, populated exclusively from ETL `src`. Nothing
+notifies on a bucket that is only an ETL `sink`, so you can configure an ETL
+that writes output to a clean bucket with nothing able to react - exactly the
+pilot (`seqreadarch` writes to its sink `input-clean`). Fix is NOT to loosen ETL
+src/sink; it is the notify consumer type plus one assembler change: attach the
+unified notifier to the UNION of {ETL source buckets} and {notify source
+buckets}, emitting exactly ONE `aws.s3.BucketNotification` per bucket (S3 allows
+one per bucket). A notify entry with `src: input-clean` wires up the sink;
+notify has no sink of its own.
+
+Per-bucket coverage the assembler must satisfy:
+
+1. ETL-source-only -> DDB dispatch (works today).
+2. notify-source-only (e.g. `input-clean` pilot) -> notify dispatch (new; needs
+   the bucket in the union).
+3. BOTH (future chained clean-bucket ETL that also notifies) -> one merged
+   notification; the single notifier consults DDB AND notify env.
+4. ETL-sink with nothing watching -> no notification (add a notify entry with
+   `src: B` to react).
+
+## ETL src/sink coupling (probed, kept as-is)
+
+Each `etl[]` entry requires a single `src` and `sink`, both resolved via
+`self.buckets[cfg[...]]`. `src` = S3 trigger attach + Glue READ grant + the
+`ETLAttrs (bucket, prefix)` lookup key; `sink` = Glue WRITE grant +
+`--SINK_BUCKET_NAME` job arg. The pin is a modeling choice, not an AWS
+constraint. The code already permits clean-as-src / raw-as-sink and even the
+same bucket as both src and sink (no directional validation). This branch keeps
+src/sink as-is (the new transform writes to the SAME sink, `input-clean`, new
+prefix). Genuine loosening (list/optional sink, cross-tributary buckets) is
+deferred to Option C. Same-bucket src=sink is loop-prone with no infra guard -
+see the loop known-issue page.
+
+## Interface contract for the separate VM branch
+
+This branch creates the notify FIFO queue and EXPOSES it as a discoverable
+component attribute (mirroring `capeinfra.data_lakehouse.athena_results_bucket`)
+so the separate instance-profile branch can grant `consume_msg` on it.
+`input-clean` and `result-raw` already exist with read/write policies.
+
+## Seqauto end-to-end chain
+
+raw upload -> `input-raw` notification -> `seqreadarch` ETL (gains an additional
+transform) writes a new-format output to `input-clean` under a NEW prefix ->
+`input-clean` notification (notify rule on that prefix) -> notify FIFO queue ->
+external puller on the VM reads, syncs from `input-clean`, writes results to
+`result-raw`.
+
+## Out of scope / future
+
+EventBridge multi-consumer eventing; ETL queue consolidation (one shared queue
+keyed by MessageGroupId); Option C config unification; DLQ/redrive; the VM
+instance-profile wiring. Never run `pulumi up`; verification is `pytest` +
+`pulumi preview --diff -s cape-cod-dev`. `Pulumi.cape-cod-public.yaml` is
+auto-generated - do not hand-edit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,10 @@ target stack and evaluate the output before the user deploys:
 - Only once the diff is understood and matches the intended scope does the user
   run the deploy. See
   `.llm-wiki/wiki/concepts/testing-and-pulumi-preview-workflow.md`.
+
+## Agent Memory
+
+- `PLAN.md` is a Pantheon/deepwork plan-gate artifact tied to whatever work is
+  in flight; keep it uncommitted. Do not add it to this repo's `.gitignore` -
+  the ignore rule belongs in the upstream shared repo that feeds this and other
+  repos. Leave `PLAN.md` untracked here.

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1834,7 +1834,20 @@ config:
                                 - tsv
                                 - txt
                       notify:
+                          # individual split read files as they land in the
+                          # clean sink (one notification per file).
                           - name: split-reads
                             src: input-clean
                             prefix: sequencing-reads-split
                             message_retention_seconds: 43200 # 12 hours
+                          # one manifest per uploaded archive, listing every
+                          # split read file extracted from it (written by
+                          # etl_seqarchive to manifest/.../manifest.csv).
+                          # consumers read it to learn the full set from an
+                          # upload; it is also crawled into the catalog (not
+                          # excluded above) so the set is queryable like
+                          # meta.csv. retention is queue-level (taken from the
+                          # first rule above), so it is not repeated here.
+                          - name: split-reads-manifest
+                            src: input-clean
+                            prefix: manifest

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1657,6 +1657,44 @@ config:
             #         ETL jobs will be queued until currently running jobs are
             #         completed and the number of running jobs is < max.
             #         Defaults to 5.
+            #       WARNING: pointing an `etl` (or `notify`, below) rule's `src`
+            #       bucket+prefix at a prefix this SAME pipeline WRITES into
+            #       (e.g. its own `sink`) creates a self-triggering loop: the
+            #       write lands back in the watched prefix and re-triggers the
+            #       rule. Keep watched prefixes disjoint from written-back
+            #       prefixes.
+            #     * `notify` (mapping[], optional)
+            #       A list of data notification rules for the tributary. Unlike
+            #       `etl`, these do not run a Glue job - they only place a
+            #       message on a per-tributary data notification queue when a
+            #       matching object shows up, for consumption outside this
+            #       pipeline. Entirely additive; a tributary with no `notify`
+            #       list gets no notification queue and no extra AWS resources.
+            #       Each list item has the following schema
+            #       * `name` (string, required)
+            #         A short name for the notification rule. Needs to be unique
+            #         across notify rules in the tributary. This value is sent
+            #         as the `notification` field of the data notification
+            #         message so consumers can identify which rule matched.
+            #       * `src` (string, required)
+            #         The id of the bucket to watch (e.g. `input-clean`). This
+            #         is *not* required to also be an `etl` source - a bucket
+            #         can be notify-only.
+            #       * `prefix` (string, required)
+            #         The object key prefix to match. Format-agnostic (works
+            #         for any file type under the prefix).
+            #       * `suffixes` (string[], optional)
+            #         A list of object (e.g. file) suffixes to limit the rule
+            #         to. If not specified (or empty), the rule matches any
+            #         suffix under `prefix`.
+            #       * `message_retention_seconds` (int, optional)
+            #         How long undelivered messages stay on the notification
+            #         queue. SQS accepts 60..1209600 seconds (14 days). If
+            #         omitted, the SQS default of 4 days (345600s) applies -
+            #         there is no true "infinite" retention. When more than one
+            #         `notify` entry is present for a tributary, the first
+            #         entry with a value set wins (all entries share one
+            #         queue).
             - name: hai
               buckets:
                   input-raw:
@@ -1795,3 +1833,8 @@ config:
                             suffixes:
                                 - tsv
                                 - txt
+                      notify:
+                          - name: split-reads
+                            src: input-clean
+                            prefix: sequencing-reads-split
+                            message_retention_seconds: 43200 # 12 hours

--- a/Pulumi.cape-cod-dev.yaml
+++ b/Pulumi.cape-cod-dev.yaml
@@ -1754,7 +1754,11 @@ config:
                       name:
                       crawler:
                           prefix: input # prefixes for tables in the database
-                          excludes: ["sequencing-reads/**"]
+                          excludes:
+                              [
+                                  "sequencing-reads/**",
+                                  "sequencing-reads-split/**",
+                              ]
                   result-raw:
                       name:
                   result-clean:

--- a/assets/etl/etl_seqarchive.py
+++ b/assets/etl/etl_seqarchive.py
@@ -63,6 +63,10 @@ sink_prefix = (
 
 reads_key = "/".join(["sequencing-reads", sink_prefix, "sequencing-reads.gz"])
 
+# collect (key, size) for each individual split read file as it is written so
+# a per-upload manifest of the full set can be emitted below.
+split_files = []
+
 # start with the gzip files
 with io.BytesIO() as gzbuff:
     # TODO:
@@ -111,12 +115,49 @@ with io.BytesIO() as gzbuff:
                 splitbuff.seek(0)
                 etl_job.write_sink_file(splitbuff, split_key)
 
+            split_files.append(
+                {"key": split_key, "size": len(bytes_for_concat)}
+            )
+
     # write out the new clean uber sequencing file
     gzbuff.seek(0)
     etl_job.write_sink_file(
         gzbuff,
         reads_key,
     )
+
+# write a manifest of the individual split read files for this upload as CSV
+# under a dedicated `manifest` prefix (one row per split file), keyed by the
+# same sink prefix as the rest of the upload's outputs. this is crawled into
+# the data catalog like meta.csv, so the set of files extracted from a single
+# uploaded archive is queryable (e.g. by sample_id or source archive). the
+# notify queue also emits a notification for this object (see the
+# `split-reads-manifest` rule in the stack config), so consumers of the
+# individual reads can learn the full set from an upload.
+manifest_fields = [
+    "sample_id",
+    "source_archive_key",
+    "sink_prefix",
+    "file_key",
+    "file_size",
+]
+manifest_buf = io.StringIO()
+manifest_writer = csv.DictWriter(manifest_buf, fieldnames=manifest_fields)
+manifest_writer.writeheader()
+for split_file in split_files:
+    manifest_writer.writerow(
+        {
+            "sample_id": sample_id,
+            "source_archive_key": archive_obj_key,
+            "sink_prefix": sink_prefix,
+            "file_key": split_file["key"],
+            "file_size": split_file["size"],
+        }
+    )
+manifest_key = "/".join(["manifest", sink_prefix, "manifest.csv"])
+with io.BytesIO(manifest_buf.getvalue().encode("utf-8")) as manifestbuff:
+    manifestbuff.seek(0)
+    etl_job.write_sink_file(manifestbuff, manifest_key)
 
 # add the s3 path to the concatenated sequencing file into meta
 concat_gz_s3loc = "/".join(

--- a/assets/etl/etl_seqarchive.py
+++ b/assets/etl/etl_seqarchive.py
@@ -14,7 +14,9 @@ etl_job = EtlJob()
 # files fastx files (fasta, fastq). The metadata will be extracted, augmented
 # for later use and then written to the clean data sink. The fastx files will be
 # contcatenated into a single gzipped fastx and also written to the clean data
-# sink. The prefix for the clean data will be constructed from the sample_id
+# sink. Each individual sequencing file is additionally written out on its own
+# (gzipped) under the `sequencing-reads-split` prefix in the clean data sink.
+# The prefix for the clean data will be constructed from the sample_id
 # (from the meta) and the current UTC date/time
 
 archive_obj_key = etl_job.parameters["OBJECT_KEY"]
@@ -86,12 +88,28 @@ with io.BytesIO() as gzbuff:
             bytes_for_concat = None
             if mn.endswith(("fasta", "fastq")):
                 etl_job.logger.info(
-                    f"input archive member is not gzipped. gzipping."
+                    "input archive member is not gzipped. gzipping."
                 )
                 bytes_for_concat = gzip.compress(br.read())
             else:
                 bytes_for_concat = br.read()
             gzbuff.write(bytes_for_concat)
+
+            # also write this member out on its own (un-concatenated) under a
+            # dedicated prefix so the per-read files are available in the clean
+            # sink. keep one consistent gzip format: fasta/fastq members were
+            # gzipped above, already-gzipped members pass through as-is.
+            member_name = mn.rsplit("/", 1)[-1]
+            if mn.endswith(("fasta", "fastq")):
+                split_name = f"{member_name}.gz"
+            else:
+                split_name = member_name
+            split_key = "/".join(
+                ["sequencing-reads-split", sink_prefix, split_name]
+            )
+            with io.BytesIO(bytes_for_concat) as splitbuff:
+                splitbuff.seek(0)
+                etl_job.write_sink_file(splitbuff, split_key)
 
     # write out the new clean uber sequencing file
     gzbuff.seek(0)

--- a/assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py
+++ b/assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py
@@ -50,6 +50,110 @@ def send_etl_message(
     )
 
 
+def send_notify_message(
+    boto3_object: Boto3Object,
+    queue_url: str | None,
+    message_group_id: str,
+    qmsg: dict,
+):
+    """Send a data notification message as json to the notify queue.
+
+    Args:
+        queue_url: The URL of the notify queue to send the message to.
+        message_group_id: The fifo message group id to use (per-object-key,
+                           so distinct objects can deliver in parallel while
+                           redeliveries of the same object collapse).
+        qmsg: A dict containing the data notification message body.
+
+    Raises:
+        ClientError: On any error in sending the message.
+    """
+    body = json.dumps(qmsg)
+    try:
+        sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody=body,
+            MessageGroupId=message_group_id,
+        )
+    except ClientError as err:
+        code, message = decode_error(err)
+
+        boto3_object.logger.exception(
+            f"Could not place message with body ({body}) on queue at URL "
+            f"({queue_url}). {code} "
+            f"{message}"
+        )
+        raise err
+
+    boto3_object.logger.info(
+        f"Message ({body}) SUCCESSFULLY placed on queue at url ({queue_url})"
+    )
+
+
+def match_notify_rules(bucket: str, key: str, rules: dict) -> list[str]:
+    """Return the names of the data notification rules that match an object.
+
+    Args:
+        bucket: The physical bucket name the object lives in.
+        key: The object's key.
+        rules: The parsed NOTIFY_RULES mapping of bucket name to a list of
+               rule objects, each with a "name", a "prefix", and an optional
+               list of "suffixes" (empty/absent means match any suffix).
+
+    Returns:
+        The names of every rule for this bucket whose prefix/suffixes match
+        the given key. Empty if the bucket has no rules or none match.
+    """
+    matched = []
+
+    for rule in rules.get(bucket, []):
+        if not key.startswith(rule["prefix"]):
+            continue
+
+        suffixes = rule.get("suffixes") or []
+        if suffixes and not any(key.endswith(suffix) for suffix in suffixes):
+            continue
+
+        matched.append(rule["name"])
+
+    return matched
+
+
+def build_notify_message(
+    raw_record: dict,
+    bucket: str,
+    key: str,
+    tributary_name: str | None,
+    notification: str,
+) -> dict:
+    """Build the body of a data notification message for a matched rule.
+
+    Args:
+        raw_record: The raw S3 notification record for the object, used for
+                    fields BucketNotificationRecord doesn't expose.
+        bucket: The object's bucket.
+        key: The object's key.
+        tributary_name: The value of the TRIBUTARY_NAME environment variable.
+        notification: The name of the matched notification rule.
+
+    Returns:
+        A dict ready to be JSON-serialized as the notify message body.
+    """
+    s3_object = raw_record.get("s3", {}).get("object", {})
+
+    return {
+        "schema_version": "1",
+        "event_time": raw_record.get("eventTime"),
+        "event_name": raw_record.get("eventName"),
+        "bucket": bucket,
+        "key": key,
+        "size": s3_object.get("size"),
+        "etag": s3_object.get("eTag"),
+        "tributary": tributary_name,
+        "notification": notification,
+    }
+
+
 def index_handler(event, context):
     """Handler for inserting notification events into a specified queue.
 
@@ -68,6 +172,22 @@ def index_handler(event, context):
     # get a reference to the etl attributes table
     ddb_table = EtlTable()
 
+    # data notification config is entirely optional/additive: when unset the
+    # handler behaves exactly as it did before data notifications existed.
+    notify_queue_name = os.getenv("NOTIFY_QUEUE_NAME")
+    notify_rules_raw = os.getenv("NOTIFY_RULES")
+    tributary_name = os.getenv("TRIBUTARY_NAME")
+
+    notify_rules = None
+    if notify_rules_raw:
+        try:
+            notify_rules = json.loads(notify_rules_raw)
+        except ValueError as err:
+            msg = f"NOTIFY_RULES is not valid JSON. {err}"
+            return {"statusCode": 500, "body": msg}
+
+    notify_queue_url = None
+
     try:
         # we'll bucket the incoming object infos and use them to send our
         # response if nothing fails miserably
@@ -79,8 +199,33 @@ def index_handler(event, context):
         response = sqs_client.get_queue_url(QueueName=queue_name)
         queue_url = response["QueueUrl"]
 
+        if notify_queue_name:
+            notify_response = sqs_client.get_queue_url(
+                QueueName=notify_queue_name
+            )
+            notify_queue_url = notify_response["QueueUrl"]
+
         for rec in event["Records"]:
             bucket_notif = BucketNotificationRecord(rec)
+
+            # data notification path: independent of the ETL path below, and
+            # a no-op unless NOTIFY_RULES has been configured for this
+            # deployment.
+            if notify_rules is not None:
+                for notification in match_notify_rules(
+                    bucket_notif.bucket, bucket_notif.key, notify_rules
+                ):
+                    qmsg = build_notify_message(
+                        rec,
+                        bucket_notif.bucket,
+                        bucket_notif.key,
+                        tributary_name,
+                        notification,
+                    )
+                    send_notify_message(
+                        ddb_table, notify_queue_url, bucket_notif.key, qmsg
+                    )
+
             # deconstruct the key (s3 name, prefix, suffix)
             prefix, _, objname = bucket_notif.key.rpartition("/")
             if not objname:

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -590,7 +590,7 @@ class Tributary(CapeComponentResource):
             environment={
                 "variables": {
                     "QUEUE_NAME": self.src_data_queue.sqs_queue.name,
-                    "ETL_ATTRS_DDB_TABLE": etl_attrs_ddb_table.name,
+                    "ETL_ATTRS_DDB_TABLE": etl_attrs_ddb_table.ddb_table.name,
                     "DDB_REGION": self.aws_region,
                 }
             },

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -133,6 +133,13 @@ class DatalakeHouse(CapeComponentResource):
         # create the parts of the datalake from the tributary configuration
         # (e.g. hai, genomics, etc)
         self.tributaries = []
+        # discoverable, config-keyed map of tributary notify queues. populated
+        # only for tributaries that declare a notify config (present-if-
+        # configured), mirroring the discoverability of
+        # self.athena_results_bucket without hard-coding any tributary name.
+        # resolving a name that declared no notify queue raises KeyError at
+        # synth time rather than yielding a silently empty grant.
+        self.notify_queues: dict[str, SQSQueue] = {}
         for trib_config in self.config.get("tributaries", default=[]):
             trib_name = trib_config.get("name")
 
@@ -160,6 +167,11 @@ class DatalakeHouse(CapeComponentResource):
                     desc_name=f"{self.desc_name} {trib_name} tributary",
                 )
             )
+            # register this tributary's notify queue for discovery only when it
+            # declared one (keyed by the config name, e.g. "seqauto").
+            tributary = self.tributaries[-1]
+            if tributary.notify_queue is not None:
+                self.notify_queues[trib_name] = tributary.notify_queue
 
 
 class CatalogDatabase(CapeComponentResource):

--- a/capeinfra/datalake/datalake.py
+++ b/capeinfra/datalake/datalake.py
@@ -1,5 +1,6 @@
 """Contains data lake related declarations."""
 
+import json
 from typing import List, Literal
 
 import pulumi_aws as aws
@@ -12,7 +13,7 @@ from capeinfra.pipeline.data import DataCrawler, EtlJob
 from capeinfra.resources.database import DynamoTable
 from capeinfra.resources.objectstorage import Bucket, VersionedBucket
 from capeinfra.resources.queue import SQSQueue
-from capepulumi import CapeComponentResource
+from capepulumi import CapeComponentResource, CapeConfig
 
 # aliases for prefixes and suffixes we expect for tributary buckets that have an
 # etl associated
@@ -267,7 +268,9 @@ class Tributary(CapeComponentResource):
             self.configure_bucket(bucket_id, crawler_attrs_ddb_table)
 
         # when new objects are put into `self.buckets` targets, a trigger
-        # function will put messages in this queue for processing down the line
+        # function will put messages in this queue for processing down the line.
+        # this queue uses a static message group id (serial per-tributary ETL
+        # processing).
         self.src_data_queue = SQSQueue(name=f"{self.name}-srcq")
 
         self.sources = set()
@@ -277,6 +280,38 @@ class Tributary(CapeComponentResource):
 
         # Lambda SQS Target setup
         self.configure_sqs_lambda_target(jobs)
+
+        # data notifications are entirely optional/additive: a tributary with
+        # no `notify` config gets no notify queue, no NOTIFY_* env vars, and no
+        # extra trigger role statements.
+        #
+        # CapeConfig.get() only wraps Mapping results, so list entries come
+        # back as plain dicts; wrap each one so per-entry `.get(..., default=)`
+        # lookups below behave like the rest of the config object.
+        self.notify_cfgs = [
+            CapeConfig(ncfg)
+            for ncfg in self.config.get(
+                "pipelines", "data", "notify", default=[]
+            )
+        ]
+        self.notify_queue = None
+        if self.notify_cfgs:
+            notify_retention_seconds = next(
+                (
+                    ncfg.get("message_retention_seconds", default=None)
+                    for ncfg in self.notify_cfgs
+                    if ncfg.get("message_retention_seconds", default=None)
+                    is not None
+                ),
+                None,
+            )
+
+            # this queue uses a per-object-key message group id (fires on
+            # objects landing in a clean/sink bucket, independent of ETL).
+            self.notify_queue = SQSQueue(
+                name=f"{self.name}-ntfq",
+                message_retention_seconds=notify_retention_seconds,
+            )
 
         # Bucket notification setup
         self.configure_src_bucket_notifications(etl_attrs_ddb_table)
@@ -535,6 +570,31 @@ class Tributary(CapeComponentResource):
                                  here will need to read from this table.
         """
 
+        # notify-config rules grouped by physical source bucket name (see
+        # below); empty unless self.notify_queue is configured. keeping this
+        # in a local named `notify_srcs` lets the role/lambda/notification-
+        # loop wiring stay a no-op when no notify config exists.
+        notify_srcs = []
+
+        put_msg_statements = [
+            self.src_data_queue.sqs_queue.arn.apply(
+                lambda arn: add_resources(
+                    self.src_data_queue.policies[SQSQueue.PolicyEnum.put_msg],
+                    arn,
+                )
+            )
+        ]
+        if self.notify_queue is not None:
+            notify_queue = self.notify_queue
+            put_msg_statements.append(
+                notify_queue.sqs_queue.arn.apply(
+                    lambda arn: add_resources(
+                        notify_queue.policies[SQSQueue.PolicyEnum.put_msg],
+                        arn,
+                    )
+                )
+            )
+
         # get a role for the source bucket trigger
         self.src_bucket_trigger_role = get_inline_role(
             f"{self.name}-s3trgrole",
@@ -543,16 +603,7 @@ class Tributary(CapeComponentResource):
             "lambda.amazonaws.com",
             aggregate_statements(
                 [capeinfra.meta.policies[CapeMeta.PolicyEnum.logging]]
-                + [
-                    self.src_data_queue.sqs_queue.arn.apply(
-                        lambda arn: add_resources(
-                            self.src_data_queue.policies[
-                                SQSQueue.PolicyEnum.put_msg
-                            ],
-                            arn,
-                        )
-                    )
-                ]
+                + put_msg_statements
                 + [
                     etl_attrs_ddb_table.ddb_table.arn.apply(
                         lambda arn: add_resources(
@@ -567,6 +618,40 @@ class Tributary(CapeComponentResource):
             "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
             opts=ResourceOptions(parent=self),
         )
+
+        env_vars = {
+            "QUEUE_NAME": self.src_data_queue.sqs_queue.name,
+            "ETL_ATTRS_DDB_TABLE": etl_attrs_ddb_table.ddb_table.name,
+            "DDB_REGION": self.aws_region,
+        }
+
+        if self.notify_queue is not None:
+            # data notification rules, grouped by the src bucket id (e.g.
+            # "input-clean") they watch. keyed by physical bucket name (below)
+            # before being handed to the Lambda, since that's what the S3
+            # event carries at runtime.
+            rules_by_src: dict[str, list[dict]] = {}
+            for ncfg in self.notify_cfgs:
+                rules_by_src.setdefault(ncfg["src"], []).append(
+                    {
+                        "name": ncfg["name"],
+                        "prefix": ncfg["prefix"],
+                        "suffixes": list(ncfg.get("suffixes", default=[])),
+                    }
+                )
+            notify_srcs = list(rules_by_src.keys())
+
+            notify_rules_json = Output.all(
+                **{src: self.buckets[src].bucket.id for src in notify_srcs}
+            ).apply(
+                lambda ids: json.dumps(
+                    {ids[src]: rules_by_src[src] for src in notify_srcs}
+                )
+            )
+
+            env_vars["NOTIFY_QUEUE_NAME"] = self.notify_queue.sqs_queue.name
+            env_vars["TRIBUTARY_NAME"] = self.name
+            env_vars["NOTIFY_RULES"] = notify_rules_json
 
         # Create our Lambda function that triggers the given glue job
         new_object_handler = aws.lambda_.Function(
@@ -587,21 +672,19 @@ class Tributary(CapeComponentResource):
             # and the actual function in the script must be named
             # the same as the value here
             handler="index.index_handler",
-            environment={
-                "variables": {
-                    "QUEUE_NAME": self.src_data_queue.sqs_queue.name,
-                    "ETL_ATTRS_DDB_TABLE": etl_attrs_ddb_table.ddb_table.name,
-                    "DDB_REGION": self.aws_region,
-                }
-            },
+            environment={"variables": env_vars},
             opts=ResourceOptions(parent=self),
             tags={
                 "desc_name": f"{self.desc_name} source data lambda trigger function"
             },
         )
 
-        # Give our function permission to invoke
-        for src in self.sources:
+        # Give our function permission to invoke. this is the union of ETL
+        # source buckets and data-notification source buckets, so a notify-
+        # only source (e.g. input-clean with no ETL reading from it) also
+        # gets wired up; when there's no notify config this is just
+        # self.sources.
+        for src in self.sources | set(notify_srcs):
             new_obj_handler_permission = aws.lambda_.Permission(
                 f"{self.name}-{src}-allow-lmbd",
                 action="lambda:InvokeFunction",

--- a/capeinfra/pipeline/data.py
+++ b/capeinfra/pipeline/data.py
@@ -128,7 +128,7 @@ class DataCrawler(CapeComponentResource):
             s3_targets=[
                 aws.glue.CrawlerS3TargetArgs(
                     path=bucket.bucket.bucket.apply(
-                        lambda b: f"s3://{b}/{prefix+'/' if prefix else ''}"
+                        lambda b: f"s3://{b}/{prefix + '/' if prefix else ''}"
                     ),
                     exclusions=self.config["excludes"],
                 )
@@ -232,6 +232,16 @@ class EtlJob(CapeComponentResource):
                     )
                     for bucket in [script_bucket]
                 ]
+                + [
+                    capeinfra.meta.capepy.uri.apply(
+                        lambda uri: add_resources(
+                            script_bucket.policies[
+                                VersionedBucket.PolicyEnum.read
+                            ],
+                            uri.replace("s3://", "arn:aws:s3:::"),
+                        )
+                    )
+                ]
             ),
             opts=ResourceOptions(parent=self),
         )
@@ -278,7 +288,9 @@ class EtlJob(CapeComponentResource):
         self.register_outputs({"job_name": self.job.name})
 
     @property
-    def policies(self) -> dict[
+    def policies(
+        self,
+    ) -> dict[
         str,
         list[aws.iam.GetPolicyDocumentStatementArgsDict],
     ]:

--- a/capeinfra/resources/queue.py
+++ b/capeinfra/resources/queue.py
@@ -22,20 +22,32 @@ class SQSQueue(CapeComponentResource):
         """Return the type_name (pulumi namespacing)."""
         return "capeinfra:resources:queue:SQSQueue"
 
-    def __init__(self, name, **kwargs):
+    def __init__(
+        self, name, message_retention_seconds: int | None = None, **kwargs
+    ):
         # This maintains parental relationships within the pulumi stack
         super().__init__(name, **kwargs)
 
         self.name = name
 
+        queue_kwargs = {
+            "name": f"{self.name}-q.fifo",
+            "content_based_deduplication": True,
+            "fifo_queue": True,
+            "opts": ResourceOptions(parent=self),
+            "tags": {"desc_name": f"{self.desc_name} SQS queue."},
+        }
+        # SQS accepts 60..1209600 seconds (14 days); leaving this unset keeps
+        # the SQS default of 4 days, so we only pass it through when given.
+        if message_retention_seconds is not None:
+            queue_kwargs["message_retention_seconds"] = (
+                message_retention_seconds
+            )
+
         self.sqs_queue = aws.sqs.Queue(
             # TODO: ISSUE #68
             f"{self.name}-q",
-            name=f"{self.name}-q.fifo",
-            content_based_deduplication=True,
-            fifo_queue=True,
-            opts=ResourceOptions(parent=self),
-            tags={"desc_name": f"{self.desc_name} SQS queue."},
+            **queue_kwargs,
         )
 
         # We also need to register all the expected outputs for this component
@@ -43,7 +55,9 @@ class SQSQueue(CapeComponentResource):
         self.register_outputs({"queue_name": self.sqs_queue.name})
 
     @property
-    def policies(self) -> dict[
+    def policies(
+        self,
+    ) -> dict[
         str,
         list[aws.iam.GetPolicyDocumentStatementArgsDict],
     ]:

--- a/capeinfra/swimlanes/private.py
+++ b/capeinfra/swimlanes/private.py
@@ -3,16 +3,11 @@
 This includes the private VPC, API/VPC endpoints and other top-level resources.
 """
 
-import itertools
-import json
-
 import pulumi_aws as aws
 from pulumi import Config, Output, ResourceOptions, warn
-from pulumi_aws.iam import GetPolicyDocumentStatementArgsDict
 from pulumi_synced_folder import S3BucketFolder
 
 import capeinfra
-from capeinfra.datalake.datalake import DatalakeHouse
 from capeinfra.iam import (
     add_resources,
     aggregate_statements,
@@ -134,7 +129,7 @@ class PrivateSwimlane(ScopedSwimlane):
         self._exposed_env_vars.setdefault(
             "ETL_ATTRS_DDB_TABLE",
             {
-                "resource_name": capeinfra.data_lakehouse.etl_attr_ddb_table.name,
+                "resource_name": capeinfra.data_lakehouse.etl_attr_ddb_table.ddb_table.name,
                 "type": "table",
             },
         )
@@ -142,7 +137,7 @@ class PrivateSwimlane(ScopedSwimlane):
         self._exposed_env_vars.setdefault(
             "CRAWLER_ATTRS_DDB_TABLE",
             {
-                "resource_name": capeinfra.data_lakehouse.crawler_attrs_ddb_table.name,
+                "resource_name": capeinfra.data_lakehouse.crawler_attrs_ddb_table.ddb_table.name,
                 "type": "table",
             },
         )
@@ -825,7 +820,9 @@ class PrivateSwimlane(ScopedSwimlane):
                     )
                     template_args["cognito_domain"] = (
                         capeinfra.meta.principals.user_pool.domain.apply(
-                            lambda d: f"https://{d}.auth.{self.aws_region}.amazoncognito.com"
+                            lambda d: (
+                                f"https://{d}.auth.{self.aws_region}.amazoncognito.com"
+                            )
                         )
                     )
                     template_args["cognito_pool_endpoint"] = (
@@ -993,14 +990,12 @@ class PrivateSwimlane(ScopedSwimlane):
 
         # we need a zone record per static app bucket
         for sa_name, sa_info in self.static_apps.items():
-
             self.create_private_domain_alb_record(
                 sa_info["bucket"].bucket.bucket, sa_name, self.APPLICATION_ALB
             )
 
         # and a zone record for each instance application
         for ia_name, ia_info in self.instance_apps.items():
-
             self.create_private_domain_alb_record(
                 ia_info["fqdn"], ia_name, self.APPLICATION_ALB
             )
@@ -1111,7 +1106,6 @@ class PrivateSwimlane(ScopedSwimlane):
         # associate the VPN endpoint with all VPN subnets and setup auth
         # rules/routes for the vpn subnets
         for sn_name, sn in self.get_subnets_by_type(SubnetType.VPN).items():
-
             # The client endpoint needs to be associated with one or more
             # subnets
             # TODO: ISSUE #100

--- a/tests/test_datalake.py
+++ b/tests/test_datalake.py
@@ -1,17 +1,20 @@
 import pulumi
 import pulumi_aws as aws
 
-# NOTE: the data notification feature (Tributary.notify_queue,
-# configure_src_bucket_notifications NOTIFY_* wiring, and the seqauto
-# split-reads notify config) is not asserted here via mock_datalake. Building
+# NOTE: the data notification feature (Tributary.notify_queue, the
+# configure_src_bucket_notifications NOTIFY_* wiring, the seqauto split-reads
+# notify config, and the config-keyed DatalakeHouse.notify_queues
+# discoverability map) is not asserted here via mock_datalake. Building
 # DatalakeHouse for that fixture already fails before it gets anywhere near a
 # tributary (test_catalog below hits a real, unmocked boto3 S3 GetObject
 # during catalog bucket construction that needs AWS creds/network), so no
-# mock-based assertion in this file can reach the notify wiring without first
-# fixing that unrelated pre-existing gap. Identity/shape of the notify
-# resources (role statement, Lambda env, per-source Permission/
-# BucketNotification) is instead verified via `pulumi preview` against the
-# dev stack, per this repo's deployment-preparation policy.
+# mock-based assertion in this file can reach the notify wiring or the
+# notify_queues map without first fixing that unrelated pre-existing gap.
+# notify_queues is a pure config-keyed dict (populated only for tributaries
+# that declare notify config), so it adds no AWS resources; its correctness
+# and the identity/shape of the notify resources (role statement, Lambda env,
+# per-source Permission/BucketNotification) are verified via `pulumi preview`
+# against the dev stack, per this repo's deployment-preparation policy.
 
 
 @pulumi.runtime.test

--- a/tests/test_datalake.py
+++ b/tests/test_datalake.py
@@ -1,6 +1,18 @@
 import pulumi
 import pulumi_aws as aws
 
+# NOTE: the data notification feature (Tributary.notify_queue,
+# configure_src_bucket_notifications NOTIFY_* wiring, and the seqauto
+# split-reads notify config) is not asserted here via mock_datalake. Building
+# DatalakeHouse for that fixture already fails before it gets anywhere near a
+# tributary (test_catalog below hits a real, unmocked boto3 S3 GetObject
+# during catalog bucket construction that needs AWS creds/network), so no
+# mock-based assertion in this file can reach the notify wiring without first
+# fixing that unrelated pre-existing gap. Identity/shape of the notify
+# resources (role statement, Lambda env, per-source Permission/
+# BucketNotification) is instead verified via `pulumi preview` against the
+# dev stack, per this repo's deployment-preparation policy.
+
 
 @pulumi.runtime.test
 def test_catalog(mock_datalake):

--- a/tests/test_notifier_lambda.py
+++ b/tests/test_notifier_lambda.py
@@ -186,3 +186,50 @@ class TestBuildNotifyMessage:
 
         assert msg["etag"] is None
         assert msg["size"] == 1234
+
+
+@pytest.fixture(scope="module")
+def deployed_rules():
+    """Rules mirroring the seqauto notify config: an individual split-reads
+    rule (match-any under its prefix) plus a manifest rule under a disjoint
+    top-level ``manifest`` prefix. Because the prefixes do not overlap, a
+    manifest object never also matches the per-file split-reads rule, so the
+    manifest stays out of the individual-file notification stream."""
+    return {
+        "input-clean-bucket": [
+            {
+                "name": "split-reads",
+                "prefix": "sequencing-reads-split",
+                "suffixes": [],
+            },
+            {
+                "name": "split-reads-manifest",
+                "prefix": "manifest",
+                "suffixes": [],
+            },
+        ]
+    }
+
+
+class TestSplitReadsManifestRouting:
+    def test_split_read_matches_only_split_reads(
+        self, notifier, deployed_rules
+    ):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "sequencing-reads-split/sample_id=s/year=2024/reads.fastq.gz",
+            deployed_rules,
+        )
+
+        assert matched == ["split-reads"]
+
+    def test_manifest_matches_only_manifest_rule(
+        self, notifier, deployed_rules
+    ):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "manifest/sample_id=s/year=2024/manifest.csv",
+            deployed_rules,
+        )
+
+        assert matched == ["split-reads-manifest"]

--- a/tests/test_notifier_lambda.py
+++ b/tests/test_notifier_lambda.py
@@ -1,0 +1,188 @@
+"""Unit tests for the S3->SQS notifier Lambda's pure notification helpers.
+
+These cover ``match_notify_rules`` and ``build_notify_message``, the two
+side-effect-free functions in the data notification path of
+``assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py``. The
+existing ETL-message path in that Lambda is untouched by this feature and is
+not re-tested here.
+
+The Lambda module calls ``boto3.client("sqs")`` at import time, which needs a
+region (but not credentials) to succeed, so ``AWS_DEFAULT_REGION`` is set
+before the module is loaded. It is a single-file Lambda (not importable as a
+package), so it is loaded from its source path, matching the
+import-inside-fixture convention used elsewhere in this suite (see
+test_workflow_user_attribution.py).
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-2")
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_module(name, relpath):
+    path = os.path.join(REPO_ROOT, relpath)
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def notifier():
+    return _load_module(
+        "new_s3obj_queue_notifier_lambda",
+        "assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py",
+    )
+
+
+@pytest.fixture(scope="module")
+def rules():
+    return {
+        "input-clean-bucket": [
+            {
+                "name": "split-reads",
+                "prefix": "sequencing-reads-split",
+                "suffixes": [],
+            },
+            {
+                "name": "split-reads-tsv",
+                "prefix": "sequencing-reads-split",
+                "suffixes": ["tsv"],
+            },
+        ]
+    }
+
+
+class TestMatchNotifyRules:
+    def test_prefix_match_hit(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.txt",
+            rules,
+        )
+
+        assert "split-reads" in matched
+
+    def test_prefix_miss(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "other-prefix/sample1.txt",
+            rules,
+        )
+
+        assert matched == []
+
+    def test_wrong_bucket_miss(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "some-other-bucket",
+            "sequencing-reads-split/sample1.txt",
+            rules,
+        )
+
+        assert matched == []
+
+    def test_suffix_filter_hit(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.tsv",
+            rules,
+        )
+
+        assert "split-reads-tsv" in matched
+
+    def test_suffix_filter_miss(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.txt",
+            rules,
+        )
+
+        assert "split-reads-tsv" not in matched
+
+    def test_empty_suffixes_matches_any(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.anything",
+            rules,
+        )
+
+        assert "split-reads" in matched
+
+    def test_absent_suffixes_matches_any(self, notifier):
+        rules_without_suffixes = {
+            "bkt": [{"name": "no-suffixes-key", "prefix": "pfx"}]
+        }
+
+        matched = notifier.match_notify_rules(
+            "bkt", "pfx/anything.weird", rules_without_suffixes
+        )
+
+        assert matched == ["no-suffixes-key"]
+
+    def test_multiple_rules_return_multiple_names(self, notifier, rules):
+        matched = notifier.match_notify_rules(
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.tsv",
+            rules,
+        )
+
+        assert set(matched) == {"split-reads", "split-reads-tsv"}
+
+
+class TestBuildNotifyMessage:
+    def test_builds_all_fields(self, notifier):
+        raw_record = {
+            "eventTime": "2024-01-01T00:00:00.000Z",
+            "eventName": "ObjectCreated:Put",
+            "s3": {
+                "object": {
+                    "size": 1234,
+                    "eTag": "abc123",
+                }
+            },
+        }
+
+        msg = notifier.build_notify_message(
+            raw_record,
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.tsv",
+            "seqauto",
+            "split-reads",
+        )
+
+        assert msg == {
+            "schema_version": "1",
+            "event_time": "2024-01-01T00:00:00.000Z",
+            "event_name": "ObjectCreated:Put",
+            "bucket": "input-clean-bucket",
+            "key": "sequencing-reads-split/sample1.tsv",
+            "size": 1234,
+            "etag": "abc123",
+            "tributary": "seqauto",
+            "notification": "split-reads",
+        }
+
+    def test_missing_etag_tolerated(self, notifier):
+        raw_record = {
+            "eventTime": "2024-01-01T00:00:00.000Z",
+            "eventName": "ObjectCreated:Put",
+            "s3": {"object": {"size": 1234}},
+        }
+
+        msg = notifier.build_notify_message(
+            raw_record,
+            "input-clean-bucket",
+            "sequencing-reads-split/sample1.tsv",
+            "seqauto",
+            "split-reads",
+        )
+
+        assert msg["etag"] is None
+        assert msg["size"] == 1234


### PR DESCRIPTION

## Test Files
[plainreads-fastq.tar.gz](https://github.com/user-attachments/files/30760085/plainreads-fastq.tar.gz)
[gzreads-fastqgz.tar.gz](https://github.com/user-attachments/files/30760088/gzreads-fastqgz.tar.gz)

## Summary

Adds config-driven S3 -> Lambda -> SQS notification plumbing to `Tributary`, piloted on the `seqauto` `input-clean` bucket, along with the ETL fixes and split-reads output that feed it. Notifications are present-if-configured: a tributary with no `notify` block gets no new resources and no behavior change, and the existing ETL trigger path is preserved unchanged.

> **This branch has already been deployed to `cape-cod-dev` and validated live.** It is not pending a first deploy; the Test procedure below documents the validation that was run (and can be re-run).

## ETL trigger fixes

- Point the ETL and crawler trigger env vars at the physical DynamoDB table name (`*.ddb_table.name`) instead of the logical name, so the notifier resolves the ETL attrs table.
- Grant the Glue ETL job role read access on the `capepy` wheel.

## seqauto split reads

- `etl_seqarchive.py` writes per-read split fastq/fasta outputs into `input-clean` under the `sequencing-reads-split` prefix.

## Notification plumbing

- Generalize the shared S3 notifier Lambda into one mediator that handles both the existing glue-etl dispatch and a new rule-driven notify path (per-object-key `MessageGroupId`, versioned metadata-rich message). ETL behavior, `ETLAttrs`, and the ETL queue are unchanged.
- Assemble each bucket's targets into a single `BucketNotification` (union of ETL and notify sources), preserving existing logical resource identity.
- Add a dedicated notify FIFO queue per configured tributary. `SQSQueue` gains an optional `message_retention_seconds` (unset keeps the SQS 4-day default; 60..1209600s allowed) - the configurable retention doubles as the queue's default cleaner.
- Add `pipelines.data.notify[]` config (name / src / prefix / optional suffixes / optional retention) with a self-trigger warning. seqauto watches `input-clean/sequencing-reads-split` at 12h retention.

## Per-upload split-read manifest

- `etl_seqarchive.py` writes one `manifest.csv` per uploaded archive under a dedicated `manifest/<sink_prefix>/` prefix (keyed by the same sink prefix as the rest of the upload's outputs), one row per split read: `sample_id`, `source_archive_key`, `sink_prefix`, `file_key`, `file_size`. A downstream consumer uses it to learn the complete set of files extracted from a single upload. Per-row duplication of the archive/sample columns is accepted for the demo.
- Add a `split-reads-manifest` notify rule (prefix `manifest`) so the notifier emits a notification pointing at the manifest. `manifest/` and `sequencing-reads-split` are disjoint prefixes, so the existing `split-reads` per-file rule is untouched and never fires on the manifest.
- Leave `manifest/` out of the `input-clean` crawler excludes so it is crawled into the catalog like `meta.csv`, making the set queryable (e.g. by `sample_id` or `source_archive_key`). No crawler infra change is needed; the next crawl run picks up the new prefix.

## Consumer discoverability

- Expose `DatalakeHouse.notify_queues`, a dict keyed by tributary config name and populated only for tributaries that declare a notify block.

## Discoverability for the upcoming VM layer

The notify queue is consumed by a separate, upcoming VM / instance-profile branch, not this one. That branch resolves the queue in-process via the `capeinfra.data_lakehouse` singleton, exactly as `private.py` already reads `capeinfra.data_lakehouse.athena_results_bucket` (same stack, plain attribute, no `StackReference` or export):

```python
notify_q = capeinfra.data_lakehouse.notify_queues["seqauto"]
```

- Keys are the tributary config `name` (e.g. `seqauto`), derived from config in the tributary loop. No tributary name is hard-coded anywhere.
- The map contains only tributaries that declared a `notify` block; resolving a name with no notify queue raises `KeyError` at Pulumi synth time, failing loud rather than granting on nothing.
- `SQSQueue` already exposes `PolicyEnum.consume_msg` (`ReceiveMessage` / `DeleteMessage` / `GetQueueAttributes`), so the VM branch attaches that policy to the instance profile. This branch does not add the grant.

## Test procedure

Prerequisite: deployed to `cape-cod-dev` (already done).

1. Clear prior artifacts: delete the existing `sequencing-reads-split` outputs, their meta files, and the `sequencing-reads` source objects from the seqauto `input-clean` bucket.
2. Upload the plain-reads and gzipped-reads archives to the seqauto raw input (both at once to exercise peak load).
3. Confirm the ETL runs and writes split fastq/fasta outputs into `input-clean/sequencing-reads-split`.
4. Confirm the notifier Lambda `ccd-dlh-T-seqauto-lmbdtrgfnct` is invoked, with CloudWatch `Errors`/`Throttles` = 0 and no exceptions in its log group.
5. Confirm the notify queue `ccd-dlh-T-seqauto-ntfq-q.fifo` holds 8 messages: 6 `split-reads` (3 archived parts per archive x 2 archives) plus 2 `split-reads-manifest` (one manifest per archive).
6. Peek a message and verify the contract: `schema_version:"1"`, S3-derived `event_time`/`event_name`, physical `bucket`, a `sequencing-reads-split/...` `key`, populated `size`/`etag`, `tributary:"ccd-dlh-T-seqauto"`, `notification:"split-reads"`.
7. Confirm filtering: only `sequencing-reads-split` objects produce messages (no leakage from other `input-clean` writes or meta files).
8. Confirm queue attributes: `FifoQueue`, `ContentBasedDeduplication`, `MessageRetentionPeriod=43200`.
9. Confirm `manifest.csv` lands under `input-clean/manifest/<sink_prefix>/` for each uploaded archive, with one row per split read (`sample_id`, `source_archive_key`, `sink_prefix`, `file_key`, `file_size`).
10. Peek the manifest messages and verify they carry `notification:"split-reads-manifest"` with a `manifest/...` `key`, distinct from the per-file `split-reads` messages.
11. Confirm the manifest is queryable in the catalog after the next crawl run (like `meta.csv`, e.g. filtering by `sample_id`).

With no consumer deployed yet, the messages self-expire at the 12h retention.

## Validation

- `pytest`: 60 pass (includes new notifier manifest-routing tests); 2 pre-existing AWS-credential failures (`test_capemeta::test_asset_bucket`, `test_datalake::test_catalog`) unrelated to this branch.
- `pulumi preview --diff -s cape-cod-dev`: no destructive ops; only additive notify resources plus in-place updates on the shared notifier/role. The discoverability change adds zero resources. The manifest augmentation also adds no resources: preview showed only in-place updates to the ETL script object and the notifier `NOTIFY_RULES` env.

Closes #361

