### PR TITLE
fix(seqauto): bound notifier FIFO MessageGroupId to SQS 128-char limit

### DIFF
--- a/.llm-wiki/wiki/sources/obs-2026-08-07-fix-368-bounded-notifier-fifo-messagegroupid-readable-prefix.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-07-fix-368-bounded-notifier-fifo-messagegroupid-readable-prefix.md
@@ -1,0 +1,25 @@
+---
+type: source
+title: "Observation: Fix #368: bounded notifier FIFO MessageGroupId (readable prefix + sha256) and decoupled notify failures"
+slug: obs-2026-08-07-fix-368-bounded-notifier-fifo-messagegroupid-readable-prefix
+status: observation
+created: 2026-08-07
+updated: 2026-08-07
+relevance: high
+observed_at: 2026-08-07T19:29:00.168Z
+tags: ["cape-cod", "sqs", "fifo", "messagegroupid", "notifier", "split-reads", "fix", "issue-368", "seqauto", "hashlib", "decouple", "new_s3obj_queue_notifier_lambda"]
+source_context: "Implementing the #368 notifier MessageGroupId 128-char fix on branch 368"
+---
+# ⭐ Observation: Fix #368: bounded notifier FIFO MessageGroupId (readable prefix + sha256) and decoupled notify failures
+Fix implemented for issue #368 on branch 368-fix-notifier-messagegroupid-128-limit (based off gh/363 tip 5c0c352, the currently-deployed branch, so a deploy stays a superset of live). File: assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py. Root cause was the notifier passing the raw S3 key as the FIFO MessageGroupId, overflowing the SQS 128-char limit for long split-read keys (see [[sources/obs-2026-08-07-notifier-bug-raw-s3-key-used-as-fifo-messagegroupid-overflow]]).
+
+Changes: (1) added `import hashlib`; (2) new pure helper derive_message_group_id(key, prefix) -> f"{prefix[:63]}-{sha256(key.encode('utf-8')).hexdigest()}" which is always <=128 chars (63 readable prefix + '-' + 64 hex) and preserves per-object-key semantics (distinct keys -> distinct groups, parallel delivery across keys, per-key ordering) since the digest is over the full key; (3) at the notify call site, group_id is computed with prefix = tributary_name or notification or "notify" and passed to send_notify_message instead of bucket_notif.key; (4) the send_notify_message call is wrapped in a local try/except ClientError that logs via ddb_table.logger.exception and continues, so a notify failure no longer aborts the ETL path or the rest of the batch (decouple); (5) send_notify_message docstring updated to describe the bounded derivation instead of "per-object-key". send_notify_message itself still raises (kept generic). Content-based dedup on the queue hashes the body, so the group-id change does not affect dedup.
+
+Scope decisions: chose Option 2 (readable prefix + hash) and the decouple hardening; DLQ/CloudWatch alarm on the notify path deferred (no Pulumi/infra change this issue). Verified locally: ruff check clean on the file, LSP clean, and a determinism/length test asserted len<=128 for 110/129/4000-char keys across short and long prefixes, deterministic output, and distinct keys yield distinct ids (module itself not importable locally because capepy is not installed, so the test replicated the helper's exact expression and cross-checked it against the source via grep). Not yet committed at time of this note; commit/push gated on explicit user approval, and deploy is user-run on the shared cape-cod-dev stack.
+*Relevance: high*
+
+*Context: Implementing the #368 notifier MessageGroupId 128-char fix on branch 368*
+
+*Tags: cape-cod sqs fifo messagegroupid notifier split-reads fix issue-368 seqauto hashlib decouple new_s3obj_queue_notifier_lambda*
+---
+*Observed: 2026-08-07T19:29:00.168Z*

--- a/.llm-wiki/wiki/sources/obs-2026-08-07-notifier-bug-raw-s3-key-used-as-fifo-messagegroupid-overflow.md
+++ b/.llm-wiki/wiki/sources/obs-2026-08-07-notifier-bug-raw-s3-key-used-as-fifo-messagegroupid-overflow.md
@@ -1,0 +1,27 @@
+---
+type: source
+title: "Observation: Notifier bug: raw S3 key used as FIFO MessageGroupId overflows the 128-char SQS limit for long split-read keys"
+slug: obs-2026-08-07-notifier-bug-raw-s3-key-used-as-fifo-messagegroupid-overflow
+status: observation
+created: 2026-08-07
+updated: 2026-08-07
+relevance: high
+observed_at: 2026-08-07T19:00:57.363Z
+tags: ["cape-cod", "sqs", "fifo", "messagegroupid", "notifier", "split-reads", "bug", "seqauto", "128-limit", "new_s3obj_queue_notifier_lambda"]
+source_context: "Confirmed SQS MessageGroupId 128-char overflow in the seqauto notifier for long split-read keys"
+---
+# ⭐ Observation: Notifier bug: raw S3 key used as FIFO MessageGroupId overflows the 128-char SQS limit for long split-read keys
+Confirmed latent bug in cape-cod notifier: assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py passes the raw S3 object key as the FIFO MessageGroupId. Call site ~line 226: send_notify_message(ddb_table, notify_queue_url, bucket_notif.key, qmsg); send_notify_message forwards it to MessageGroupId (line 76). SQS caps MessageGroupId at 128 chars. Split-read keys of form sequencing-reads-split/<sink_prefix>/<leaf> can exceed 128 (observed: read key 129 chars = 1 over -> InvalidParameterValue; manifest key 110 = under -> enqueues fine, which is why only the manifest landed). Failure is effectively silent: object is already in S3, notifier only logs. Worse, send_notify_message RE-RAISES the ClientError, which propagates to index_handler's outer except ClientError (returns 500), so for that record the downstream ETL enqueue and any remaining batch records are also skipped. S3->Lambda async invoke retries twice then drops, and an oversized key fails deterministically.
+
+Design context (from the FIFO grill note obs-2026-08-04): the group id is intentionally PER-OBJECT-KEY to isolate head-of-line blocking and allow parallel delivery across keys; the notify queue uses CONTENT-BASED dedup (hashes body, event_time sourced from S3 record). So MessageGroupId is independent of dedup - changing the group-id derivation does NOT disturb dedup.
+
+Fix options (pending user direction, no changes made): (1) hash the key: MessageGroupId = sha256(key).hexdigest() (64 chars, bounded, one group per distinct key, preserves per-key parallelism/ordering; downside: not human-readable) - RECOMMENDED; (2) readable prefix + hash suffix, e.g. f"{tributary_name}-{sha256(key).hexdigest()[:32]}" capped to 128 (same safety, debuggable); (3) group by structural component (sink_prefix/sample_id) - changes semantics (serializes leaves under a sink, less parallelism) and still needs a length guard; (4) truncate key to 128 - REJECTED (collides on shared directory prefixes). MessageGroupId allowed chars include alphanumerics + punctuation, so a hex digest is valid.
+
+Secondary hardening decisions (independent of option): (a) decouple notify failures from the ETL path / rest of batch by catching notify errors locally; (b) make failure non-silent via DLQ or CloudWatch alarm on the notify path. Process: fix lives in this repo, deployed shared Lambda (shared-stack deploy-ordering caution applies), wants its own branch/issue separate from #366.
+*Relevance: high*
+
+*Context: Confirmed SQS MessageGroupId 128-char overflow in the seqauto notifier for long split-read keys*
+
+*Tags: cape-cod sqs fifo messagegroupid notifier split-reads bug seqauto 128-limit new_s3obj_queue_notifier_lambda*
+---
+*Observed: 2026-08-07T19:00:57.363Z*

--- a/assets/report/bactopia-single-sample-analysis/data_function.py
+++ b/assets/report/bactopia-single-sample-analysis/data_function.py
@@ -68,7 +68,7 @@ where
 # document (see etl_caerbannog_results.py). recreates the consumer's per-target
 # sample results table: one row per detected target. column order here must
 # match the report template headers, which render row values in order. the
-# consumer's home tab hides `clear`-status targets by default (a togglable
+# consumer's home tab hides `clear`-status targets by default (a toggleable
 # display setting); a static report has no toggle, so the rows are fetched here
 # and split into active vs cleared tables in python rather than dropped.
 # TODO(#363): the join-key correspondence between this sample_id and the

--- a/assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py
+++ b/assets/trigger-functions/s3/new_s3obj_queue_notifier_lambda.py
@@ -1,5 +1,6 @@
 """Lambda function for kicking off Epi/HAI Glue Jobs."""
 
+import hashlib
 import json
 import os
 
@@ -50,6 +51,29 @@ def send_etl_message(
     )
 
 
+def derive_message_group_id(key: str, prefix: str) -> str:
+    """Build a FIFO MessageGroupId that stays within the SQS 128-char limit.
+
+    SQS rejects any MessageGroupId longer than 128 characters, so the raw
+    object key cannot be used directly: long split-read keys overflow the
+    limit and the send fails. We preserve the per-object-key semantics
+    (distinct keys map to distinct groups, so notifications deliver in
+    parallel across keys and stay ordered per key) by hashing the full key,
+    and prepend a short readable prefix for debuggability.
+
+    Args:
+        key: The full S3 object key the message is about.
+        prefix: A readable label (e.g. tributary or rule name), truncated to
+                63 chars so the total stays within the 128-char limit.
+
+    Returns:
+        A group id of the form "<prefix[:63]>-<sha256 hex>", always <= 128
+        characters (63 + 1 + 64).
+    """
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return f"{prefix[:63]}-{digest}"
+
+
 def send_notify_message(
     boto3_object: Boto3Object,
     queue_url: str | None,
@@ -60,9 +84,12 @@ def send_notify_message(
 
     Args:
         queue_url: The URL of the notify queue to send the message to.
-        message_group_id: The fifo message group id to use (per-object-key,
-                           so distinct objects can deliver in parallel while
-                           redeliveries of the same object collapse).
+        message_group_id: The FIFO message group id to use. Callers pass a
+                           bounded id (see derive_message_group_id) that stays
+                           within the SQS 128-char limit while preserving
+                           per-key grouping, so distinct objects deliver in
+                           parallel and redeliveries of the same object stay in
+                           one group.
         qmsg: A dict containing the data notification message body.
 
     Raises:
@@ -222,9 +249,22 @@ def index_handler(event, context):
                         tributary_name,
                         notification,
                     )
-                    send_notify_message(
-                        ddb_table, notify_queue_url, bucket_notif.key, qmsg
+                    group_id = derive_message_group_id(
+                        bucket_notif.key,
+                        tributary_name or notification or "notify",
                     )
+                    try:
+                        send_notify_message(
+                            ddb_table, notify_queue_url, group_id, qmsg
+                        )
+                    except ClientError as err:
+                        code, message = decode_error(err)
+                        ddb_table.logger.exception(
+                            "Failed to enqueue data notification for "
+                            f"({bucket_notif.bucket}, {bucket_notif.key}); "
+                            "continuing so the ETL path is unaffected. "
+                            f"{code} {message}"
+                        )
 
             # deconstruct the key (s3 name, prefix, suffix)
             prefix, _, objname = bucket_notif.key.rpartition("/")


### PR DESCRIPTION
**Fix**

- The notifier passed the raw S3 object key as the FIFO `MessageGroupId`. SQS caps `MessageGroupId` at 128 chars, so long split-read keys (`sequencing-reads-split/<sink_prefix>/<leaf>`) were rejected with `InvalidParameterValue` and their notifications silently dropped.
- Derive a bounded `MessageGroupId`: a readable prefix (tributary or rule name, truncated to 63 chars) plus a sha256 hex digest of the full key, always `<= 128` chars. This preserves the per-object-key semantics (distinct keys map to distinct groups, parallel delivery across keys, per-key ordering); content-based dedup hashes the body and is unaffected.
- Decouple notify failures: catch the notify `SendMessage` error at the call site and continue, so one bad notification no longer aborts the ETL path or the rest of the batch.

**Deferred**

- DLQ / CloudWatch alarm on the notify path (follow-up, no infra change here).

**Validation**

- `ruff` clean; local check confirms `len <= 128` for 110/129/4000-char keys across short and long prefixes, deterministic output, and distinct keys yield distinct ids.

**Base**

- Stacked on `363-...` (the currently-deployed branch), so this should merge after or together with that branch.

Closes #368