### PR TITLE
fix(reports): repoint bactopia single-sample data function to input_meta

### DIFF
--- a/assets/report/bactopia-single-sample-analysis/data_function.py
+++ b/assets/report/bactopia-single-sample-analysis/data_function.py
@@ -22,7 +22,7 @@ select
     -- pipeline information
     rsv.run_date, rsv.bactopia_version, 'bactopia' AS pipeline_name
 from
-    "{database}"."input_ccd_dlh_t_seqauto_input_clean_vbkt_s3_b1f75c7" as m
+    "{database}"."input_meta" as m
 join
     "{database}"."result_software_versions" as rsv on
     rsv.input_file=m.sequencing_reads
@@ -52,7 +52,7 @@ select
     -- needed for filtering of results
     ramrfp.type, ramrfp.method
 from
-    "{database}"."input_ccd_dlh_t_seqauto_input_clean_vbkt_s3_b1f75c7" as m
+    "{database}"."input_meta" as m
 join
     "{database}"."result_software_versions" as rsv on
     rsv.input_file=m.sequencing_reads
@@ -148,6 +148,14 @@ def data_function(event, context):
             ),
             database=database,
         )
+
+        if meta_df.empty:
+            msg = (
+                f"No metadata found for sample {sample_id} in database "
+                f"{database}. Data function cannot continue"
+            )
+            logger.error(msg)
+            raise ValueError(msg)
 
         row = meta_df.iloc[0]
 


### PR DESCRIPTION
**Problem**
- The report queried the Glue table `input_ccd_dlh_t_seqauto_input_clean_vbkt_s3_b1f75c7`, which Glue's default crawler grouping froze and orphaned once a second sibling prefix (`manifest/`) appeared under the crawled bucket root. New meta partitions now land only in `input_meta`, so the metadata query returned zero rows and the data function crashed at `meta_df.iloc[0]` with an opaque `IndexError`.

**Change**
- Repoint `METADATA_QRY_TEMPLATE` and `VIRULENCE_INFO_QRY_TEMPLATE` to `input_meta`.
- Guard the empty-result case with a clear `ValueError` naming the sample and database instead of the `IndexError`.

**Scope**
- Report data function only. No infra or catalog changes. The deeper catalog namespacing redesign (prefix derived from bucket key, forced folder-level grouping, reserved prefixes) is deferred to a post-demo migration.

**Validation**
- The `input_meta` swap was verified working against the deployed system for sample `abcdefghij`. File passes Python lint clean.

Fixes #371
